### PR TITLE
이미지 등록/삭제 기능

### DIFF
--- a/src/components/ImagePreviewModal/ImagePreviewModal.jsx
+++ b/src/components/ImagePreviewModal/ImagePreviewModal.jsx
@@ -1,0 +1,44 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { SvgIcon } from "../SvgIcon/SvgIcon";
+import useLockBodyScroll from "../../hooks/useLockBodyScroll";
+
+export default function ImagePreviewModal({ previewUrl, onClose }) {
+  if (!previewUrl) return null;
+
+  useLockBodyScroll(previewUrl);
+
+  const isDark = document.documentElement.classList.contains("dark");
+  // 또는 const isDark = useDarkMode(); 
+
+  return (
+    <div className={[
+            "fixed inset-0 z-50",
+            "bg-black bg-opacity-80",
+            "flex items-center justify-center",
+        ].join(" ")}
+    >
+      <div className="relative p-7">
+        <img
+          src={previewUrl}
+          alt="확대 이미지"
+          className={[
+            "w-full tablet:w-[600px] desktop:w-[700px]",
+            "rounded shadow-lg",
+          ].join(" ")}
+        />
+        <SvgIcon
+          name="delete"
+          frameClass={isDark ? "absolute top-4 right-4 bg text-2xl" : "absolute top-4 right-4 bg text-2xl text-white rounded-full hover:bg-[var(--color-gray-4)] transition cursor-pointer"}
+          onClick={onClose}
+          fill
+        />
+      </div>
+    </div>
+  );
+}
+
+ImagePreviewModal.propTypes = {
+  previewUrl: PropTypes.string,
+  onClose: PropTypes.func.isRequired,
+};

--- a/src/components/ImagePreviewModal/ImagePreviewModal.stories.jsx
+++ b/src/components/ImagePreviewModal/ImagePreviewModal.stories.jsx
@@ -1,0 +1,36 @@
+import React, { useState } from "react";
+import ImagePreviewModal from "./ImagePreviewModal";
+
+export default {
+    title: "Components/Common/ImagePreviewModal",
+    component: ImagePreviewModal,
+    parameters: {
+        layout: "centered",
+    },
+};
+
+const Template = (args) => {
+    const [isOpen, setIsOpen] = useState(true);
+
+    return (
+        <>
+            <button
+                className="px-4 py-2 bg-blue-500 text-white rounded"
+                onClick={() => setIsOpen(true)}
+            >
+                Show Preview Modal
+            </button>
+            <ImagePreviewModal
+                {...args}
+                previewUrl={isOpen ? args.previewUrl : null}
+                onClose={() => setIsOpen(false)}
+            />
+        </>
+    );
+};
+
+export const Default = Template.bind({});
+Default.args = {
+    previewUrl:
+        "https://placehold.co/600x400?text=Preview+Image",
+};

--- a/src/components/RadioListItem/RadioListItem.jsx
+++ b/src/components/RadioListItem/RadioListItem.jsx
@@ -1,0 +1,74 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+export default function RadioListItem({
+    options,
+    name,
+    value,
+    onChange,
+    RadioListItemclassName,
+    state = "default",
+}) {
+    const isDisabled = state === "disable";
+
+    return (
+        <div className={[
+            "flex flex-wrap gap-x-4 gap-y-2 pb-2",
+            RadioListItemclassName,
+        ].join(" ")}>
+            {options.map((option) => (
+                <label
+                    key={option.value}
+                    className={[
+                        "flex items-center gap-2 shrink-0",
+                        isDisabled ? "cursor-not-allowed opacity-50" : "cursor-pointer",
+                    ].join(" ")}
+                >
+                    <input
+                        type="radio"
+                        name={name}
+                        value={option.value}
+                        checked={value === option.value}
+                        disabled={isDisabled}
+                        onChange={(e) => onChange(e.target.value)}
+                        className={[
+                            "appearance-none w-[18px] h-[18px] rounded-full border-2",
+                            "transition-colors",
+                            // state === "disable" ? "" : "hover:border-[var(--color-gray-8)]",
+                            state === "hover" ? "border-[var(--color-gray-8)]" : "border-[var(--color-gray-3)]",
+                            value === option.value ? "border-[var(--color-gray-8)] bg-[var(--color-primary)] border-4" : "",
+                            isDisabled ? "cursor-not-allowed opacity-50" : "cursor-pointer",
+                        ].join(" ")}
+                    />
+                    <p className={value === option.value ? "text-[var(--color-gray-8)]" : "text-[var(--color-gray-6)]"}>
+                        {option.label}
+                    </p>
+                </label>
+            ))}
+        </div>
+    );
+}
+
+RadioListItem.propTypes = {
+    options: PropTypes.arrayOf(PropTypes.shape({
+        value: PropTypes.string,
+        label: PropTypes.string,
+    })).isRequired,
+    name: PropTypes.string.isRequired,
+    value: PropTypes.string.isRequired,
+    onChange: PropTypes.func.isRequired,
+    RadioListItemclassName: PropTypes.string,
+    state: PropTypes.oneOf(["default", "hover", "disable", "checked"]),
+};
+
+
+{/* <RadioListItem
+    options={[
+        { value: "option1", label: "옵션 1" },
+        { value: "option2", label: "옵션 2" },
+    ]}
+    name="example"
+    value={selected}
+    onChange={setSelected}
+    state="default" // "hover", "disable", "checked" 로 바꿔 테스트 가능
+/> */}

--- a/src/components/RadioListItem/RadioListItem.jsx
+++ b/src/components/RadioListItem/RadioListItem.jsx
@@ -32,7 +32,7 @@ export default function RadioListItem({
                         disabled={isDisabled}
                         onChange={(e) => onChange(e.target.value)}
                         className={[
-                            "appearance-none w-[18px] h-[18px] rounded-full border-2",
+                            "inline-block shrink-0 aspect-square appearance-none w-[18px] h-[18px] rounded-full border-2",
                             "transition-colors",
                             state === "disable" ? "" : "hover:border-[var(--color-gray-8)]",
                             state === "hover" ? "border-[var(--color-gray-8)]" : "border-[var(--color-gray-3)]",

--- a/src/components/RadioListItem/RadioListItem.jsx
+++ b/src/components/RadioListItem/RadioListItem.jsx
@@ -34,7 +34,7 @@ export default function RadioListItem({
                         className={[
                             "appearance-none w-[18px] h-[18px] rounded-full border-2",
                             "transition-colors",
-                            // state === "disable" ? "" : "hover:border-[var(--color-gray-8)]",
+                            state === "disable" ? "" : "hover:border-[var(--color-gray-8)]",
                             state === "hover" ? "border-[var(--color-gray-8)]" : "border-[var(--color-gray-3)]",
                             value === option.value ? "border-[var(--color-gray-8)] bg-[var(--color-primary)] border-4" : "",
                             isDisabled ? "cursor-not-allowed opacity-50" : "cursor-pointer",

--- a/src/components/RadioListItem/RadioListItem.stories.jsx
+++ b/src/components/RadioListItem/RadioListItem.stories.jsx
@@ -1,0 +1,58 @@
+import React, { useState } from "react";
+import RadioListItem from "./RadioListItem";
+
+export default {
+    title: "Components/RadioListItem",
+    component: RadioListItem,
+    argTypes: {},
+};
+
+const Template = (args) => {
+    const [selected, setSelected] = useState("option1");
+    return (
+        <RadioListItem
+            {...args}
+            value={selected}
+            onChange={setSelected}
+        />
+    );
+};
+
+export const Default = Template.bind({});
+Default.args = {
+    name: "radio",
+    options: [
+        { value: "option1", label: "옵션 1" },
+        { value: "option2", label: "옵션 2" },
+        { value: "option3", label: "옵션 3" },
+    ],
+    state: "default",
+};
+
+export const Hover = Template.bind({});
+Hover.args = {
+    name: "radio",
+    options: [
+        { value: "option1", label: "옵션 1" },
+        { value: "option2", label: "옵션 2" },
+    ],
+    state: "hover",
+};
+
+export const Disable = Template.bind({});
+Disable.args = {
+    name: "radio",
+    options: [
+        { value: "option1", label: "옵션 1" },
+    ],
+    state: "disable",
+};
+
+export const Checked = Template.bind({});
+Checked.args = {
+    name: "radio",
+    options: [
+        { value: "option1", label: "옵션 1" },
+    ],
+    state: "checked",
+};

--- a/src/components/SelectImageGroup/SelectImage.jsx
+++ b/src/components/SelectImageGroup/SelectImage.jsx
@@ -21,6 +21,7 @@ export default function SelectImage({
         "border border-dashed rounded-lg border-[var(--color-gray-3)]",
         "bg-cover bg-center",
         "flex items-center justify-center",
+        "hover:shadow-lg",
         "transition",
         isDisabled && "opacity-50 cursor-not-allowed",
         className,
@@ -54,7 +55,7 @@ export default function SelectImage({
                 />
                 )}
             </button>
-            
+
             {isRemovable && (
                 <SelectImageDeleteButton
                     onClick={onRemoveImage}

--- a/src/components/SelectImageGroup/SelectImage.jsx
+++ b/src/components/SelectImageGroup/SelectImage.jsx
@@ -1,57 +1,75 @@
 import React from "react";
 import PropTypes from "prop-types";
 import SvgIcon from "../SvgIcon/SvgIcon";
+import SelectImageDeleteButton from "./SelectImageDeleteButton";
 
-export default function SelectImage({ imageUrl, onSelectImage, className = "", state = "default" }) {
+export default function SelectImage({
+    imageUrl,
+    onSelectImage,
+    onRemoveImage,
+    isRemovable = false,
+    className = "",
+    state = "default",
+}) {
     const isDisabled = state === "disable";
+    const isUploaded = !!imageUrl;
 
-    const baseClasses = [
-        "w-[100px] h-[100px]",
+    // ✅ 업로드된 상태 스타일
+    const uploadedClasses = [
+        "relative",
+        "w-[80px] h-[80px]",
+        "border border-dashed rounded-lg border-[var(--color-gray-3)]",
+        "bg-cover bg-center",
+        "flex items-center justify-center",
+        "transition",
+        isDisabled && "opacity-50 cursor-not-allowed",
+        className,
+    ].filter(Boolean);
+
+    // ✅ 빈 슬롯(업로드 버튼) 상태 스타일
+    const emptyClasses = [
+        "w-[80px] h-[80px]",
         "border border-dashed rounded-lg border-[var(--color-gray-3)]",
         "flex items-center justify-center",
-        state === "disable" ? "" : "hover:bg-[var(--color-gray-2)]",
+        state === "hover" && "bg-[var(--color-gray-2)]",
+        !isDisabled && "hover:bg-[var(--color-gray-2)]",
         "transition",
         className,
-        imageUrl ? "bg-cover bg-center" : "",
-    ];
-
-    if (state === "hover") {
-        baseClasses.push("bg-[var(--color-gray-2)]");
-    }
-
-    if (isDisabled) {
-        baseClasses.push("opacity-50 cursor-not-allowed");
-    }
+    ].filter(Boolean);
 
     return (
-        <button
-            type="button"
-            onClick={onSelectImage}
-            className={baseClasses.join(" ")}
-            style={imageUrl ? { backgroundImage: `url(${imageUrl})` } : {}}
-            disabled={isDisabled}
-        >
-            {!imageUrl && (
-                <SvgIcon 
+        <div className="relative">
+            <button
+                type="button"
+                onClick={onSelectImage}
+                className={isUploaded ? uploadedClasses.join(" ") : emptyClasses.join(" ")}
+                style={isUploaded ? { backgroundImage: `url(${imageUrl})` } : {}}
+                disabled={isDisabled}
+            >
+                {!isUploaded && (
+                <SvgIcon
                     name="camera"
                     hoverEffect={false}
                     state={state}
                 />
+                )}
+            </button>
+            
+            {isRemovable && (
+                <SelectImageDeleteButton
+                    onClick={onRemoveImage}
+                    state={state === "hover" ? "hover" : "default"}
+                />
             )}
-        </button>
+        </div>
     );
 }
 
 SelectImage.propTypes = {
-    imageUrl: PropTypes.string,
-    onSelectImage: PropTypes.func.isRequired,
-    className: PropTypes.string,
-    state: PropTypes.oneOf(["default", "hover", "disable"]),
+  imageUrl: PropTypes.string,
+  onSelectImage: PropTypes.func.isRequired,
+  onRemoveImage: PropTypes.func,
+  isRemovable: PropTypes.bool,
+  className: PropTypes.string,
+  state: PropTypes.oneOf(["default", "hover", "disable"]),
 };
-
-
-{/* <SelectImage
-    imageUrl={imageUrl}
-    onSelectImage={handleSelectImage}
-    state="default" // "hover" or "disable"
-/> */}

--- a/src/components/SelectImageGroup/SelectImage.jsx
+++ b/src/components/SelectImageGroup/SelectImage.jsx
@@ -1,0 +1,57 @@
+import React from "react";
+import PropTypes from "prop-types";
+import SvgIcon from "../SvgIcon/SvgIcon";
+
+export default function SelectImage({ imageUrl, onSelectImage, className = "", state = "default" }) {
+    const isDisabled = state === "disable";
+
+    const baseClasses = [
+        "w-[100px] h-[100px]",
+        "border border-dashed rounded-lg border-[var(--color-gray-3)]",
+        "flex items-center justify-center",
+        state === "disable" ? "" : "hover:bg-[var(--color-gray-2)]",
+        "transition",
+        className,
+        imageUrl ? "bg-cover bg-center" : "",
+    ];
+
+    if (state === "hover") {
+        baseClasses.push("bg-[var(--color-gray-2)]");
+    }
+
+    if (isDisabled) {
+        baseClasses.push("opacity-50 cursor-not-allowed");
+    }
+
+    return (
+        <button
+            type="button"
+            onClick={onSelectImage}
+            className={baseClasses.join(" ")}
+            style={imageUrl ? { backgroundImage: `url(${imageUrl})` } : {}}
+            disabled={isDisabled}
+        >
+            {!imageUrl && (
+                <SvgIcon 
+                    name="camera"
+                    hoverEffect={false}
+                    state={state}
+                />
+            )}
+        </button>
+    );
+}
+
+SelectImage.propTypes = {
+    imageUrl: PropTypes.string,
+    onSelectImage: PropTypes.func.isRequired,
+    className: PropTypes.string,
+    state: PropTypes.oneOf(["default", "hover", "disable"]),
+};
+
+
+{/* <SelectImage
+    imageUrl={imageUrl}
+    onSelectImage={handleSelectImage}
+    state="default" // "hover" or "disable"
+/> */}

--- a/src/components/SelectImageGroup/SelectImage.stories.jsx
+++ b/src/components/SelectImageGroup/SelectImage.stories.jsx
@@ -1,0 +1,31 @@
+import React from "react";
+import SelectImage from "./SelectImage";
+
+export default {
+    title: "Components/SelectImage",
+    component: SelectImage,
+    argTypes: {},
+};
+
+const Template = (args) => <SelectImage {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+    imageUrl: "",
+    state: "default",
+    onSelectImage: () => alert("이미지 선택"),
+};
+
+export const Hover = Template.bind({});
+Hover.args = {
+    imageUrl: "",
+    state: "hover",
+    onSelectImage: () => alert("이미지 선택"),
+};
+
+export const Disable = Template.bind({});
+Disable.args = {
+    imageUrl: "",
+    state: "disable",
+    onSelectImage: () => alert("이미지 선택"),
+};

--- a/src/components/SelectImageGroup/SelectImage.stories.jsx
+++ b/src/components/SelectImageGroup/SelectImage.stories.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import SelectImage from "./SelectImage";
 
 export default {
-    title: "Components/SelectImage",
+    title: "Components/Common/SelectImage",
     component: SelectImage,
     argTypes: {},
 };

--- a/src/components/SelectImageGroup/SelectImageDeleteButton.jsx
+++ b/src/components/SelectImageGroup/SelectImageDeleteButton.jsx
@@ -1,0 +1,34 @@
+import React from "react";
+import PropTypes from "prop-types";
+import SvgIcon from "../SvgIcon/SvgIcon";
+
+export default function SelectImageDeleteButton({
+  onClick,
+  state = "default",
+}) {
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            className={[
+                "absolute top-1 right-1 z-10 flex items-center justify-center",
+                "w-[16px] h-[16px] rounded-full border transition",
+                "bg-[var(--color-gray-1)]",
+                "border border-[var(--color-gray-2)]",
+                state === "hover"
+                ? "bg-[var(--color-gray-9)] "
+                : "hover:bg-[var(--color-gray-2)] hover:border-[var(--color-gray-3)]",
+            ].join(" ")}
+        >
+        <SvgIcon 
+            name="delete"
+            iconClass="w-[10px] h-[10px]"
+        />
+        </button>
+    );
+}
+
+SelectImageDeleteButton.propTypes = {
+  onClick: PropTypes.func.isRequired,
+  state: PropTypes.oneOf(["default", "hover"]),
+};

--- a/src/components/SelectImageGroup/SelectImageDeleteButton.stories.jsx
+++ b/src/components/SelectImageGroup/SelectImageDeleteButton.stories.jsx
@@ -1,0 +1,31 @@
+import React from "react";
+import SelectImageDeleteButton from "./SelectImageDeleteButton";
+
+export default {
+    title: "Components/Common/SelectImageDeleteButton",
+    component: SelectImageDeleteButton,
+    argTypes: {
+        state: {
+        control: "select",
+        options: ["default", "hover"],
+        },
+    },
+};
+
+const Template = (args) => (
+    <div className="relative w-[100px] h-[100px] bg-[var(--color-gray-2)]">
+        <SelectImageDeleteButton {...args} />
+    </div>
+);
+
+export const Default = Template.bind({});
+Default.args = {
+    state: "default",
+    onClick: () => alert("삭제 버튼 클릭됨!"),
+};
+
+export const Hover = Template.bind({});
+Hover.args = {
+    ...Default.args,
+    state: "hover",
+};

--- a/src/components/SelectImageGroup/SelectImageGroup.jsx
+++ b/src/components/SelectImageGroup/SelectImageGroup.jsx
@@ -1,19 +1,23 @@
-import React, { useState } from "react";
+import React from "react";
 import PropTypes from "prop-types";
 import RadioListItem from "../RadioListItem/RadioListItem";
-import SelectImage from "./SelectImage";
+import SelectImageList from "./SelectImageList";
 
 export default function SelectImageGroup({
     title = "",
     radioOptions = [],
     selectedValue,
     onChangeValue,
-    imageUrl,
-    onSelectImage,
+    images = [],         // ✅ 배열로 변경
+    onAddImage,          // ✅ 새로 추가
+    onRemoveImage,       // ✅ 새로 추가
     RadioListItemclassName,
     SelectImageclassName,
-    state = "default", // ✅ 공통 상태
+    state = "default",
+    maxCount = 3,        // ✅ 최대 업로드 수
 }) {
+    const showUploadButton = images.length < maxCount;
+
     return (
         <div className="w-full">
             {title && (
@@ -32,11 +36,13 @@ export default function SelectImageGroup({
             />
 
             {selectedValue === "checked" && (
-                <SelectImage
-                    imageUrl={imageUrl}
-                    onSelectImage={onSelectImage}
-                    className={SelectImageclassName}
+                <SelectImageList
+                    images={images}
+                    onAddImage={onAddImage}
+                    onRemoveImage={onRemoveImage}
+                    SelectImageclassName={SelectImageclassName}
                     state={state}
+                    maxCount={maxCount}
                 />
             )}
         </div>
@@ -53,9 +59,11 @@ SelectImageGroup.propTypes = {
     ),
     selectedValue: PropTypes.string.isRequired,
     onChangeValue: PropTypes.func.isRequired,
-    imageUrl: PropTypes.string,
-    onSelectImage: PropTypes.func.isRequired,
+    images: PropTypes.arrayOf(PropTypes.string), // ✅ 배열
+    onAddImage: PropTypes.func.isRequired,       // ✅ 필수
+    onRemoveImage: PropTypes.func.isRequired,    // ✅ 필수
     RadioListItemclassName: PropTypes.string,
     SelectImageclassName: PropTypes.string,
     state: PropTypes.oneOf(["default", "hover", "disable", "checked"]),
+    maxCount: PropTypes.number,
 };

--- a/src/components/SelectImageGroup/SelectImageGroup.jsx
+++ b/src/components/SelectImageGroup/SelectImageGroup.jsx
@@ -1,0 +1,59 @@
+import React from "react";
+import PropTypes from "prop-types";
+import RadioListItem from "../RadioListItem/RadioListItem";
+import SelectImage from "./SelectImage";
+
+export default function SelectImageGroup({
+    title = "",
+    radioOptions = [],
+    selectedValue,
+    onChangeValue,
+    imageUrl,
+    onSelectImage,
+    RadioListItemclassName,
+    SelectImageclassName,
+    state = "default", // ✅ 공통 상태
+}) {
+    return (
+        <div className="w-full">
+            {title && (
+                <h3 className="mb-2 font-bold text-[var(--color-gray-8)]">
+                    {title}
+                </h3>
+            )}
+
+            <RadioListItem
+                options={radioOptions}
+                name="select-image-group"
+                value={selectedValue}
+                onChange={onChangeValue}
+                RadioListItemclassName={RadioListItemclassName}
+                state={state === "disable" ? "disable" : selectedValue === "checked" ? "checked" : state}
+            />
+
+            <SelectImage
+                imageUrl={imageUrl}
+                onSelectImage={onSelectImage}
+                className={SelectImageclassName}
+                state={state}
+            />
+        </div>
+    );
+}
+
+SelectImageGroup.propTypes = {
+    title: PropTypes.string,
+    radioOptions: PropTypes.arrayOf(
+        PropTypes.shape({
+            value: PropTypes.string,
+            label: PropTypes.string,
+        })
+    ),
+    selectedValue: PropTypes.string.isRequired,
+    onChangeValue: PropTypes.func.isRequired,
+    imageUrl: PropTypes.string,
+    onSelectImage: PropTypes.func.isRequired,
+    RadioListItemclassName: PropTypes.string,
+    SelectImageclassName: PropTypes.string,
+    state: PropTypes.oneOf(["default", "hover", "disable", "checked"]),
+};

--- a/src/components/SelectImageGroup/SelectImageGroup.jsx
+++ b/src/components/SelectImageGroup/SelectImageGroup.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import PropTypes from "prop-types";
 import RadioListItem from "../RadioListItem/RadioListItem";
 import SelectImage from "./SelectImage";
@@ -31,12 +31,14 @@ export default function SelectImageGroup({
                 state={state === "disable" ? "disable" : selectedValue === "checked" ? "checked" : state}
             />
 
-            <SelectImage
-                imageUrl={imageUrl}
-                onSelectImage={onSelectImage}
-                className={SelectImageclassName}
-                state={state}
-            />
+            {selectedValue === "checked" && (
+                <SelectImage
+                    imageUrl={imageUrl}
+                    onSelectImage={onSelectImage}
+                    className={SelectImageclassName}
+                    state={state}
+                />
+            )}
         </div>
     );
 }

--- a/src/components/SelectImageGroup/SelectImageGroup.stories.jsx
+++ b/src/components/SelectImageGroup/SelectImageGroup.stories.jsx
@@ -1,0 +1,63 @@
+import React, { useState } from "react";
+import SelectImageGroup from "./SelectImageGroup";
+
+export default {
+    title: "Components/SelectImageGroup",
+    component: SelectImageGroup,
+    argTypes: {},
+};
+
+const Template = (args) => {
+    const [selectedValue, setSelectedValue] = useState("default");
+    const [imageUrl, setImageUrl] = useState("");
+
+    return (
+        <SelectImageGroup
+            {...args}
+            selectedValue={selectedValue}
+            onChangeValue={setSelectedValue}
+            imageUrl={imageUrl}
+            onSelectImage={() => alert("이미지 선택")}
+        />
+    );
+};
+
+export const Default = Template.bind({});
+Default.args = {
+    title: "프로필 이미지",
+    radioOptions: [
+        { value: "default", label: "기본 이미지" },
+        { value: "checked", label: "직접 선택" },
+    ],
+    state: "default",
+};
+
+export const Hover = Template.bind({});
+Hover.args = {
+    title: "프로필 이미지",
+    radioOptions: [
+        { value: "default", label: "기본 이미지" },
+        { value: "checked", label: "직접 선택" },
+    ],
+    state: "hover",
+};
+
+export const Disable = Template.bind({});
+Disable.args = {
+    title: "프로필 이미지",
+    radioOptions: [
+        { value: "default", label: "기본 이미지" },
+        { value: "checked", label: "직접 선택" },
+    ],
+    state: "disable",
+};
+
+export const Checked = Template.bind({});
+Checked.args = {
+    title: "프로필 이미지",
+    radioOptions: [
+        { value: "default", label: "기본 이미지" },
+        { value: "checked", label: "직접 선택" },
+    ],
+    state: "checked",
+};

--- a/src/components/SelectImageGroup/SelectImageList.jsx
+++ b/src/components/SelectImageGroup/SelectImageList.jsx
@@ -1,0 +1,57 @@
+import React from "react";
+import PropTypes from "prop-types";
+import SelectImage from "./SelectImage";
+
+export default function SelectImageList({
+  images = [],
+  onAddImage,
+  onRemoveImage,
+  SelectImageclassName = "",
+  state = "default",
+  maxCount = 3,
+}) {
+  const showUploadButton = images.length < maxCount;
+
+  return (
+    <div className="flex gap-2 flex-wrap">
+        {showUploadButton && (
+            <label htmlFor="group-upload">
+                <SelectImage
+                    imageUrl=""
+                    onSelectImage={() => document.getElementById("group-upload").click()}
+                    className={SelectImageclassName}
+                    state={state}
+                />
+                <input
+                    id="group-upload"
+                    type="file"
+                    accept="image/*"
+                    onChange={onAddImage}
+                    className="hidden"
+                />
+            </label>
+        )}
+
+        {images.map((image, index) => (
+            <SelectImage
+                key={index}
+                imageUrl={image}
+                onSelectImage={() => {}}
+                onRemoveImage={() => onRemoveImage(index)}
+                isRemovable
+                className={SelectImageclassName}
+                state={state}
+            />
+        ))}
+    </div>
+  );
+}
+
+SelectImageList.propTypes = {
+  images: PropTypes.arrayOf(PropTypes.string).isRequired,
+  onAddImage: PropTypes.func.isRequired,
+  onRemoveImage: PropTypes.func.isRequired,
+  SelectImageclassName: PropTypes.string,
+  state: PropTypes.oneOf(["default", "hover", "disable", "checked"]),
+  maxCount: PropTypes.number,
+};

--- a/src/components/SelectImageGroup/SelectImageList.jsx
+++ b/src/components/SelectImageGroup/SelectImageList.jsx
@@ -1,6 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
 import SelectImage from "./SelectImage";
+import useImagePreview from "@/hooks/useImagePreview";
+import ImagePreviewModal from "../ImagePreviewModal/ImagePreviewModal";
 
 export default function SelectImageList({
   images = [],
@@ -12,38 +14,48 @@ export default function SelectImageList({
 }) {
   const showUploadButton = images.length < maxCount;
 
+  // ✅ 미리보기 훅 사용
+  const { previewUrl, openPreview, closePreview } = useImagePreview();
+
   return (
-    <div className="flex gap-2 flex-wrap">
+    <>
+      <div className="flex gap-2 flex-wrap">
         {showUploadButton && (
-            <label htmlFor="group-upload">
-                <SelectImage
-                    imageUrl=""
-                    onSelectImage={() => document.getElementById("group-upload").click()}
-                    className={SelectImageclassName}
-                    state={state}
-                />
-                <input
-                    id="group-upload"
-                    type="file"
-                    accept="image/*"
-                    onChange={onAddImage}
-                    className="hidden"
-                />
-            </label>
+          <label htmlFor="group-upload">
+            <SelectImage
+              imageUrl=""
+              onSelectImage={() =>
+                document.getElementById("group-upload").click()
+              }
+              className={SelectImageclassName}
+              state={state}
+            />
+            <input
+              id="group-upload"
+              type="file"
+              accept="image/*"
+              onChange={onAddImage}
+              className="hidden"
+            />
+          </label>
         )}
 
         {images.map((image, index) => (
-            <SelectImage
-                key={index}
-                imageUrl={image}
-                onSelectImage={() => {}}
-                onRemoveImage={() => onRemoveImage(index)}
-                isRemovable
-                className={SelectImageclassName}
-                state={state}
-            />
+          <SelectImage
+            key={index}
+            imageUrl={image}
+            onSelectImage={() => openPreview(image)} // ✅ 클릭 시 확대!
+            onRemoveImage={() => onRemoveImage(index)}
+            isRemovable
+            className={SelectImageclassName}
+            state={state}
+          />
         ))}
-    </div>
+      </div>
+
+      {/* ✅ 미리보기 모달 */}
+      <ImagePreviewModal previewUrl={previewUrl} onClose={closePreview} />
+    </>
   );
 }
 

--- a/src/components/SelectImageGroup/SelectImageList.stories.jsx
+++ b/src/components/SelectImageGroup/SelectImageList.stories.jsx
@@ -1,19 +1,15 @@
 import React, { useState } from "react";
-import SelectImageGroup from "./SelectImageGroup";
+import SelectImageList from "./SelectImageList";
 
 export default {
-  title: "Components/Common/SelectImageGroup",
-  component: SelectImageGroup,
+    title: "Components/Common/SelectImageList",
+    component: SelectImageList,
+    argTypes: {},
 };
 
 const Template = (args) => {
-    const [selectedValue, setSelectedValue] = useState(
-        args.selectedValue || "default"
-    );
-    const [images, setImages] = useState(
-        args.initialImages || []
-    );
-    const MAX_COUNT = 3;
+    const [images, setImages] = useState(args.initialImages || []);
+    const MAX_COUNT = args.maxCount || 3;
 
     const handleAddImage = (e) => {
         const file = e.target.files[0];
@@ -38,10 +34,8 @@ const Template = (args) => {
     };
 
     return (
-        <SelectImageGroup
+        <SelectImageList
         {...args}
-        selectedValue={selectedValue}
-        onChangeValue={setSelectedValue}
         images={images}
         onAddImage={handleAddImage}
         onRemoveImage={handleRemoveImage}
@@ -52,12 +46,8 @@ const Template = (args) => {
 
 export const Default = Template.bind({});
 Default.args = {
-    title: "프로필 이미지",
-    radioOptions: [
-        { value: "default", label: "기본 이미지" },
-        { value: "checked", label: "직접 선택" },
-    ],
     state: "default",
+    maxCount: 3,
 };
 
 export const Hover = Template.bind({});
@@ -72,12 +62,11 @@ Disable.args = {
     state: "disable",
 };
 
-export const Checked = Template.bind({});
-Checked.args = {
+export const Filled = Template.bind({});
+Filled.args = {
     ...Default.args,
-    state: "checked",
-    selectedValue: "checked",
     initialImages: [
-        "https://picsum.photos/200/200?random=1"
+        "https://picsum.photos/100/100?random=1",
+        "https://picsum.photos/100/100?random=2",
     ],
 };

--- a/src/components/SvgIcon/SvgIcon.jsx
+++ b/src/components/SvgIcon/SvgIcon.jsx
@@ -23,7 +23,8 @@ export const SvgIcon = ({
     fill = false,
     frameClass = "",
     iconClass = "",
-    hoverEffect = true // hoverEffect가 false이면 hover 효과 없이 기본 색만 적용
+    hoverEffect = true, // hoverEffect가 false이면 hover 효과 없이 기본 색만 적용
+    onClick
 }) => {
     const frameSizeClass = SIZE_CLASSES[frameSize] || SIZE_CLASSES["md"];
     const iconSizeClass = SIZE_CLASSES[iconSize] || SIZE_CLASSES["xs"];
@@ -50,8 +51,9 @@ export const SvgIcon = ({
             ${stateClass} 
             ${hoverfillClass}
             ${frameClass}
-            `
-        }>
+            `}
+        onClick={onClick}
+        >
             <svg
                 className={`${iconSizeClass} ${iconClass}`}
                 aria-hidden="true"
@@ -70,6 +72,7 @@ SvgIcon.propTypes = {
     state: PropTypes.oneOf(["default", "disable", "hover", "hoverFill"]),
     fill: PropTypes.bool,
     className: PropTypes.string,
+    onClick: PropTypes.func,
 };
 
 export default SvgIcon;

--- a/src/hooks/useImagePreview.js
+++ b/src/hooks/useImagePreview.js
@@ -1,0 +1,19 @@
+import { useState } from "react";
+
+export default function useImagePreview() {
+  const [previewUrl, setPreviewUrl] = useState(null);
+
+  const openPreview = (url) => {
+    setPreviewUrl(url);
+  };
+
+  const closePreview = () => {
+    setPreviewUrl(null);
+  };
+
+  return {
+    previewUrl,
+    openPreview,
+    closePreview,
+  };
+}

--- a/src/hooks/useProfileImages.js
+++ b/src/hooks/useProfileImages.js
@@ -1,0 +1,35 @@
+import { useState } from "react";
+
+export default function useProfileImages(maxCount = 3) {
+    const [images, setImages] = useState([]);
+
+    // 추가
+    const handleAddImage = (e) => {
+        const file = e.target.files[0];
+        if (!file) return;
+
+        if (images.length >= maxCount) {
+        alert(`이미지는 최대 ${maxCount}개까지 업로드할 수 있어요.`);
+        return;
+        }
+
+        const reader = new FileReader();
+        reader.onloadend = () => {
+        setImages((prev) => [...prev, reader.result]);
+        };
+        reader.readAsDataURL(file);
+        e.target.value = null;
+    };
+
+    // 삭제
+    const handleRemoveImage = (index) => {
+        setImages((prev) => prev.filter((_, i) => i !== index));
+        alert("이미지가 삭제되었습니다!");
+    };
+
+    return {
+        images,
+        handleAddImage,
+        handleRemoveImage,
+    };
+}

--- a/src/pages/Test.jsx
+++ b/src/pages/Test.jsx
@@ -1,11 +1,14 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import BaseButton from '../components/BaseButton/BaseButton';
 import CustomButton from '../components/CustomButton/CustomButton';
 import SvgIcon from '../components/SvgIcon/SvgIcon';
+import SelectImageGroup from '../components/SelectImageGroup/SelectImageGroup';
 
 const Test = () => {
     const navigate = useNavigate();
+    const [selected, setSelected] = useState("option1");
+    const [image, setImage] = useState("");
 
     return (
         <div className="flex min-h-screen flex-col items-center justify-center px-4 bg-[var(--color-primary)] transition-colors duration-300">
@@ -48,6 +51,24 @@ const Test = () => {
                 // svgIconClass="bg-black"
                 // basebuttonClass="bg-black"
                 custombuttonClass="tablet:w-[320px]"
+            />
+
+            <SelectImageGroup
+                title="프로필 이미지 선택"
+                SelectImageGroupclassName="py-4"
+                RadioListItemclassName="py-2"
+                SelectImageclassName=""
+                radioOptions={[
+                    { value: "default", label: "기본 이미지" },
+                    { value: "checked", label: "선택 이미지" },
+                ]}
+                selectedValue={selected}
+                onChangeValue={setSelected}
+                imageUrl={image}
+                onSelectImage={() => {
+                    alert("이미지 업로드!");
+                }}
+                state="default" // "default", "hover", "disable"
             />
         </div>
     );

--- a/src/pages/Test.jsx
+++ b/src/pages/Test.jsx
@@ -9,6 +9,7 @@ const Test = () => {
     const navigate = useNavigate();
     const [selected, setSelected] = useState("option1");
     const [image, setImage] = useState("");
+    const [selectedValue, setSelectedValue] = useState("default"); // ✅ 기본값
 
     return (
         <div className="flex min-h-screen flex-col items-center justify-center px-4 bg-[var(--color-primary)] transition-colors duration-300">
@@ -58,12 +59,12 @@ const Test = () => {
                 SelectImageGroupclassName="py-4"
                 RadioListItemclassName="py-2"
                 SelectImageclassName=""
+                selectedValue={selectedValue}
+                onChangeValue={setSelectedValue}
                 radioOptions={[
                     { value: "default", label: "기본 이미지" },
                     { value: "checked", label: "선택 이미지" },
                 ]}
-                selectedValue={selected}
-                onChangeValue={setSelected}
                 imageUrl={image}
                 onSelectImage={() => {
                     alert("이미지 업로드!");

--- a/src/pages/Test.jsx
+++ b/src/pages/Test.jsx
@@ -4,12 +4,12 @@ import BaseButton from '../components/BaseButton/BaseButton';
 import CustomButton from '../components/CustomButton/CustomButton';
 import SvgIcon from '../components/SvgIcon/SvgIcon';
 import SelectImageGroup from '../components/SelectImageGroup/SelectImageGroup';
+import useProfileImages from "@/hooks/useProfileImages";
 
 const Test = () => {
     const navigate = useNavigate();
-    const [selected, setSelected] = useState("option1");
-    const [image, setImage] = useState("");
     const [selectedValue, setSelectedValue] = useState("default"); // ✅ 기본값
+    const { images, handleAddImage, handleRemoveImage } = useProfileImages(3);
 
     return (
         <div className="flex min-h-screen flex-col items-center justify-center px-4 bg-[var(--color-primary)] transition-colors duration-300">
@@ -65,11 +65,10 @@ const Test = () => {
                     { value: "default", label: "기본 이미지" },
                     { value: "checked", label: "선택 이미지" },
                 ]}
-                imageUrl={image}
-                onSelectImage={() => {
-                    alert("이미지 업로드!");
-                }}
-                state="default" // "default", "hover", "disable"
+                images={images}           // ✅ 배열!
+                onAddImage={handleAddImage}   // ✅ 파일 선택
+                onRemoveImage={handleRemoveImage} // ✅ 개별 삭제
+                state="default" // "default", "hover", "disable", "checked"
             />
         </div>
     );


### PR DESCRIPTION
# PR 서식

- PR 이름 : 이미지 등록/삭제 기능 추가 및 미리보기 모달 연동

- 수정한 이슈 : #16 

## 반영 브랜치
- feature/select-image → develop

## PR 유형

- [x] 새로운 기능 추가
- [x] CSS 등 사용자 UI 디자인 변경
- [x] 코드 리팩토링

## PR 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] 문서에 해당 변경 사항을 업데이트 했습니다.
- [x] 해당 변경은 에러를 발생시키지 않았습니다.

### PR 상세(활동 및 수정사항)

- **이미지 선택 및 등록 기능 구현**
  - `SelectImage` : 이미지 업로드 버튼 및 업로드된 이미지 썸네일 표시
  - `SelectImageList` : 업로드된 이미지 리스트 관리, 이미지 개별 삭제 기능 포함
  - `SelectImageGroup` : 라디오 선택과 함께 이미지 그룹 등록 지원, 최대 업로드 수 제한 처리
  - `SelectImageDeleteButton` : 이미지 삭제 버튼 분리 컴포넌트화

- **이미지 미리보기 모달 연결**
  - `useImagePreview` 훅으로 미리보기 상태 관리
  - `ImagePreviewModal`에서 확대 이미지 확인 가능

- **스토리북 작성**
  - 각 컴포넌트별(`SelectImage`, `SelectImageList`, `SelectImageGroup`, `SelectImageDeleteButton`) 상태별 스토리 작성
  - 업로드/삭제 동작 테스트 가능하도록 예시 추가

- **기타**
  - 스타일 개선 및 상태별 hover/disable 처리
  - SvgIcon `onClick` prop 추가하여 재사용성 향상
  - 전체 코드 컨벤션 리팩토링

## Screenshots

| 기능 | 화면 |
|------|------|
| 📸 이미지 업로드 | ![스크린샷 2025-07-09 오전 11 05 15](https://github.com/user-attachments/assets/dd6bd6ee-90d0-4b5b-bd9a-694d6cdc2d1a) |
| 🗑️ 이미지 삭제 완료 | <img src="https://github.com/user-attachments/assets/061274ed-0073-445c-9ddf-9363ca6f177e" width="200" alt="이미지 삭제" />|
| 🔍 이미지 미리보기 모달 | <img src="https://github.com/user-attachments/assets/ebb6a378-e7b3-40f6-a3a4-39f0f95e86c1" width="200" alt="이미지 미리보기 모달" /> |

### ⚙️ 추가 동작 예시 (GIF)

![Jul-08-2025 10-46-15](https://github.com/user-attachments/assets/bd6d9911-95b9-4aec-9be4-086e9a6d4c44)
