### PR TITLE
요리모임 작성 Autosave 도입 (/post/create)

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -18,6 +18,7 @@ export default function Header({
     buttonGroupClass = "",
     onButtonTitleClick,
     buttons = [],
+    buttonTitle = ""
 }) {
     const location = useLocation();
     const navigate = useNavigate();
@@ -61,8 +62,8 @@ export default function Header({
     const showTitle = mergedConfig.showTitle ?? true;
     const icon2Name = mergedConfig.Icon2Name ?? Icon2Name;
     const onShowIcon2Merged = mergedConfig.onShowIcon2 ?? onShowIcon2;
-    const buttonTitle =
-    mergedConfig.buttonTitle !== undefined ? mergedConfig.buttonTitle : buttonTitle;
+    const mergedButtonTitle =
+        mergedConfig.buttonTitle !== undefined ? mergedConfig.buttonTitle : buttonTitle;
     const showButtonTitle =
         typeof mergedConfig.showButtonTitle === "function"
             ? mergedConfig.showButtonTitle({ user })
@@ -219,11 +220,10 @@ export default function Header({
                         showButtonTitle && (
                             <li>
                                 <CustomButton
-                                    text={buttonTitle}
+                                    text={mergedButtonTitle}
                                     size="sm"
                                     variant="secondary"
                                     onClick={onButtonTitleClick}
-                                    state={btn.state}
                                 />
                             </li>
                         )
@@ -277,4 +277,5 @@ Header.propTypes = {
     buttonGroupClass: PropTypes.string,
     onButtonTitleClick: PropTypes.func,
     fill: PropTypes.bool,
+    buttonTitle: PropTypes.string,
 };

--- a/src/components/Input/Input.jsx
+++ b/src/components/Input/Input.jsx
@@ -95,7 +95,7 @@ const Input = ({
     useLockBodyScroll(isModalOpen);
     
     return (
-        <form className={`flex flex-col gap-1 w-full ${className}`}>
+        <div className={`flex flex-col gap-1 w-full ${className}`}>
             {label && (
                 <label className="
                     font-bold 
@@ -218,7 +218,7 @@ const Input = ({
                     </span>
                 </div>
             ))}
-        </form>
+        </div>
     );
 };
 

--- a/src/hooks/usePostAutosave.js
+++ b/src/hooks/usePostAutosave.js
@@ -1,0 +1,190 @@
+import { useEffect, useRef } from "react";
+
+export default function usePostAutosave({
+    step, setStep,
+    formData, setFormData,
+    images, handleAddImage,
+    draftKey = "postCreateAutosave_v1",
+    createPath = "/post/create",
+    confirmLeaveMsg = "작성중인 모임이 있습니다. 임시저장 하겠습니까?",
+    confirmResumeMsg = "임시저장된 모임이 있습니다. 이어서 작성하시겠습니까?",
+    completeStep = 8, // 완료 단계 번호
+}) {
+    const stepRef = useRef(step);
+    const formRef = useRef(formData);
+    const imagesRef = useRef(images);
+    const disabledRef = useRef(false);  // 완료 시 가드 비활성화 플래그
+    const handlersRef = useRef({});     // 리스너 참조 저장
+
+    useEffect(() => { stepRef.current = step; }, [step]);
+    useEffect(() => { formRef.current = formData; }, [formData]);
+    useEffect(() => { imagesRef.current = images; }, [images]);
+
+    const filesToDataUrls = (files = []) =>
+        Promise.all([...files].map(file => new Promise((resolve) => {
+            const reader = new FileReader();
+            reader.onload = () => resolve({ name: file.name, type: file.type, dataUrl: reader.result });
+            reader.readAsDataURL(file);
+        })));
+
+    const dataUrlToFile = async ({ name = "image", type = "image/*", dataUrl }) => {
+        const res = await fetch(dataUrl);
+        const blob = await res.blob();
+        return new File([blob], name, { type: blob.type || type });
+    };
+
+    const loadDraft = () => {
+        try { return JSON.parse(localStorage.getItem(draftKey) || "null"); }
+        catch { return null; }
+    };
+    const clearAutosave = () => localStorage.removeItem(draftKey);
+
+    const hasDirty = () => {
+        const f = formRef.current || {};
+        const textDirty =
+            f.title?.trim() ||
+            f.description?.trim() ||
+            (f.category?.length || 0) > 0 ||
+            f.address?.trim() ||
+            f.date?.trim() ||
+            f.timeStart?.trim() ||
+            f.timeEnd?.trim() ||
+            (f.capacity && f.capacity !== "2") ||
+            (!f.isFreeClass && (f.fee && f.fee !== "10,000"));
+        const imgDirty = (imagesRef.current?.length || 0) > 0;
+        return !!(textDirty || imgDirty);
+    };
+
+    const saveDraft = async () => {
+        try {
+            const imagePayload = await filesToDataUrls(imagesRef.current || []);
+            const payload = {
+                formData: formRef.current,
+                step: stepRef.current,
+                images: imagePayload,
+                savedAt: Date.now(),
+            };
+            localStorage.setItem(draftKey, JSON.stringify(payload));
+            return true;
+        } catch (e) {
+            console.error("임시저장 실패:", e);
+            return false;
+        }
+    };
+
+    const restoreDraft = async (draft) => {
+        if (!draft) return;
+        try {
+            const { formData: savedForm, step: savedStep, images: savedImages } = draft;
+            setFormData((s) => ({ ...s, ...savedForm }));
+            if (typeof savedStep === "number" && savedStep >= 0 && savedStep <= 7) {
+                setStep(savedStep);
+            }
+            if (Array.isArray(savedImages) && savedImages.length > 0) {
+                for (const meta of savedImages) {
+                    const file = await dataUrlToFile(meta);
+                    handleAddImage(file);
+                }
+            }
+        } catch (e) {
+            console.error("임시저장 복원 실패:", e);
+        }
+    };
+
+    const shouldGuard = (fromPath, toPath) =>
+        fromPath.startsWith(createPath) && toPath && !toPath.startsWith(createPath);
+
+    const confirmAndMaybeSave = () => {
+        if (disabledRef.current || stepRef.current === completeStep || !hasDirty()) return true;
+        const doSave = window.confirm(confirmLeaveMsg);
+        if (doSave) saveDraft();
+        else clearAutosave();
+        return true;
+    };
+
+    useEffect(() => {
+        // 진입 시 이어쓰기 여부
+        const draft = loadDraft();
+        if (draft) {
+            const resume = window.confirm(confirmResumeMsg);
+            if (resume) restoreDraft(draft);
+            else clearAutosave();
+        }
+
+        const onPopState = () => {
+            if (disabledRef.current || stepRef.current === completeStep) return;
+            confirmAndMaybeSave();
+        };
+
+        const onDocumentClick = (e) => {
+            if (disabledRef.current || stepRef.current === completeStep) return;
+            const a = e.target.closest?.("a[href]");
+            if (!a) return;
+            const url = new URL(a.getAttribute("href"), location.href);
+            if (url.origin !== location.origin) return;
+            const from = location.pathname;
+            const to = url.pathname;
+            if (!shouldGuard(from, to) || !hasDirty()) return;
+            e.preventDefault();
+            const doSave = window.confirm(confirmLeaveMsg);
+            const go = () => { location.href = url.href; };
+            if (doSave) saveDraft().finally(go);
+            else { clearAutosave(); go(); }
+        };
+
+        const origPush = history.pushState;
+        const origReplace = history.replaceState;
+        const wrap = (orig) => function wrapped(state, title, url) {
+            if (!(disabledRef.current || stepRef.current === completeStep)) {
+                try {
+                    const toUrl = typeof url === "string" ? new URL(url, location.href) : null;
+                    const toPath = toUrl ? toUrl.pathname : location.pathname;
+                    const fromPath = location.pathname;
+                    if (shouldGuard(fromPath, toPath) && hasDirty()) {
+                        confirmAndMaybeSave();
+                    }
+                } catch {}
+            }
+            return orig.apply(this, arguments);
+        };
+        history.pushState = wrap(origPush);
+        history.replaceState = wrap(origReplace);
+
+        const onBeforeUnload = (e) => {
+            if (disabledRef.current || stepRef.current === completeStep || !hasDirty()) return;
+            e.preventDefault();
+            e.returnValue = "";
+        };
+
+        window.addEventListener("popstate", onPopState);
+        document.addEventListener("click", onDocumentClick, true);
+        window.addEventListener("beforeunload", onBeforeUnload);
+
+        handlersRef.current = { onPopState, onDocumentClick, onBeforeUnload, origPush, origReplace };
+
+        return () => {
+            window.removeEventListener("popstate", onPopState);
+            document.removeEventListener("click", onDocumentClick, true);
+            window.removeEventListener("beforeunload", onBeforeUnload);
+            history.pushState = origPush;
+            history.replaceState = origReplace;
+        };
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    // 완료 단계에 도달하면 즉시 가드 비활성화 + 리스너 해제 + 초안 정리
+    useEffect(() => {
+        if (step === completeStep) {
+            disabledRef.current = true;
+            const h = handlersRef.current || {};
+            if (h.onPopState) window.removeEventListener("popstate", h.onPopState);
+            if (h.onDocumentClick) document.removeEventListener("click", h.onDocumentClick, true);
+            if (h.onBeforeUnload) window.removeEventListener("beforeunload", h.onBeforeUnload);
+            if (h.origPush) history.pushState = h.origPush;
+            if (h.origReplace) history.replaceState = h.origReplace;
+            clearAutosave(); // 혹시 남아있을 수 있는 초안 제거
+        }
+    }, [step, completeStep]);
+
+    return { saveDraft, restoreDraft, loadDraft, clearAutosave, hasDirty };
+}

--- a/src/pages/PostCreate.jsx
+++ b/src/pages/PostCreate.jsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect } from "react";
 import pb from "../lib/pocketbase";
+import useProfileImages from "../hooks/useProfileImages";
+import usePostAutosave from "../hooks/usePostAutosave";
 import Input from "../components/Input/Input";
 import RadioListItem from "../components/RadioListItem/RadioListItem";
 import CustomButton from "../components/CustomButton/CustomButton";
@@ -7,7 +9,6 @@ import PageTitleBar from "../components/PageTitleBar/PageTitleBar";
 import SelectImageGroup from "../components/SelectImageGroup/SelectImageGroup";
 import SvgIcon from '../components/SvgIcon/SvgIcon';
 import Header from "../components/Header/Header";
-import useProfileImages from "../hooks/useProfileImages";
 import { Swiper, SwiperSlide } from "swiper/react";
 import "swiper/css";
 import TimeInput from "../components/TimeWheelPicker/TimeInput";
@@ -66,6 +67,14 @@ export default function PostCreate() {
         fee: "10,000",
     });
     const [isSubmitting, setIsSubmitting] = useState(false);
+    const { clearAutosave } = usePostAutosave({
+        step,
+        setStep,
+        formData,
+        setFormData,
+        images,
+        handleAddImage,
+    });
 
     // 사용자
         const user = pb.authStore.model;
@@ -89,21 +98,21 @@ export default function PostCreate() {
         const makeCountSub = (len, max) => [{ text: `${len}/${max}`, type: "info" }];
 
         const makeTitleSubs = (text) => {
-        const len = (text || "").length;
-        const subs = makeCountSub(len, 40);
-        if (!text || !text.trim()) return [{ text: `${len}/40`, type: "info" }];
-        if (!ALLOW_RE.test(text)) return [{ text: "특수문자는 사용할 수 없어요.", type: "error" }, ...subs];
-        if (len > 40) return [{ text: "최대 40자까지 입력 가능해요.", type: "error" }, ...subs];
-        return subs;
+            const len = (text || "").length;
+            const subs = makeCountSub(len, 40);
+            if (!text || !text.trim()) return [{ text: `${len}/40`, type: "info" }];
+            if (!ALLOW_RE.test(text)) return [{ text: "특수문자는 사용할 수 없어요.", type: "error" }, ...subs];
+            if (len > 40) return [{ text: "최대 40자까지 입력 가능해요.", type: "error" }, ...subs];
+            return subs;
         };
 
         const makeDescSubs = (text) => {
-        const len = (text || "").length;
-        const subs = makeCountSub(len, 1000);
-        if (!text || !text.trim()) return [{ text: `${len}/1000`, type: "info" }];
-        if (!ALLOW_RE.test(text)) return [{ text: "특수문자는 사용할 수 없어요.", type: "error" }, ...subs];
-        if (len > 1000) return [{ text: "최대 1000자까지 입력 가능해요.", type: "error" }, ...subs];
-        return subs;
+            const len = (text || "").length;
+            const subs = makeCountSub(len, 1000);
+            if (!text || !text.trim()) return [{ text: `${len}/1000`, type: "info" }];
+            if (!ALLOW_RE.test(text)) return [{ text: "특수문자는 사용할 수 없어요.", type: "error" }, ...subs];
+            if (len > 1000) return [{ text: "최대 1000자까지 입력 가능해요.", type: "error" }, ...subs];
+            return subs;
         };
 
         // 필드별 유효여부
@@ -183,61 +192,74 @@ export default function PostCreate() {
 
         // 인원 변경 핸들러
         const setCapacity = (next) => {
-        const clamped = Math.max(0, Math.min(99, next)); // 입력 깔끔히
-        setFormData((s) => ({ ...s, capacity: String(clamped) }));
+            const clamped = Math.max(0, Math.min(99, next)); // 입력 깔끔히
+            setFormData((s) => ({ ...s, capacity: String(clamped) }));
         };
 
         const handleCapacityInput = (e) => {
-        const digits = onlyDigitsCapacity(e.target.value);
-        setFormData((s) => ({ ...s, capacity: digits }));
+            const digits = onlyDigitsCapacity(e.target.value);
+            setFormData((s) => ({ ...s, capacity: digits }));
         };
 
         // 화살표 증감
         const incCapacity = () => {
-        const n = Number(onlyDigitsCapacity(formData.capacity || "0")) || 0;
-        if (n >= 20) return;
-        setCapacity(n + 1);
+            const n = Number(onlyDigitsCapacity(formData.capacity || "0")) || 0;
+            if (n >= 20) return;
+            setCapacity(n + 1);
         };
         const decCapacity = () => {
-        const n = Number(onlyDigitsCapacity(formData.capacity || "0")) || 0;
-        if (n <= 2) return;
-        setCapacity(n - 1);
+            const n = Number(onlyDigitsCapacity(formData.capacity || "0")) || 0;
+            if (n <= 2) return;
+            setCapacity(n - 1);
         };
 
     // PocketBase 저장
         const savePostToPocketBase = async () => {
             if (isSubmitting) return;
             setIsSubmitting(true);
-
+        
             try {
-                const form = new FormData();
-                form.append("title", formData.title);
-                form.append("editor", userId);
-                form.append("description", formData.description);
-                form.append("location", formData.address);
-                form.append("date", formData.date);
-                form.append("timeStart", formData.timeStart);
-                form.append("timeEnd", formData.timeEnd);
-                form.append("capacity", formData.capacity);
-                
-                const asNumber = (s) => Number(onlyDigits(s || "0"));
-                form.append("fee", String(asNumber(formData.fee)));
-
-                formData.category.forEach((cat) => form.append("category", cat));
-
-                images.forEach((file) => {
+                const fd = new FormData();
+                const toNum = (s) => Number((s || "").replace(/[^\d]/g, ""));
+                const trim = (s) => (s || "").trim();
+        
+                // 문자열 필드
+                fd.append("title", trim(formData.title));
+                fd.append("description", trim(formData.description));
+                fd.append("location", trim(formData.address));
+                fd.append("date", formData.date);
+                fd.append("timeStart", formData.timeStart);
+                fd.append("timeEnd", formData.timeEnd);
+        
+                // 숫자 필드
+                fd.append("capacity", String(toNum(formData.capacity)));
+                fd.append("fee", String(toNum(formData.fee)));
+        
+                // 멀티값: JSON 문자열로 한 번에
+                fd.append("category", JSON.stringify(formData.category || []));
+        
+                // 파일
+                images.forEach((file, i) => {
                     if (file instanceof File) {
-                        form.append("images", file);
+                        fd.append("images", file, file.name || `image-${i}.jpg`);
                     }
                 });
-
-                const record = await pb.collection("post").create(form);
-                    console.log("저장 성공:", record);
-                    nextStep();
-                } catch (error) {
-                    console.error("저장 실패:", error);
-                } finally {
-                    setIsSubmitting(false);
+        
+                // 스키마에서 허용될 때만 사용 (규칙으로 자동 채우면 제외)
+                if (userId) {
+                    fd.append("editor", userId);
+                }
+        
+                const record = await pb.collection("post").create(fd);
+                console.log("저장 성공:", record);
+                clearAutosave?.();
+                nextStep();
+            } catch (error) {
+                const details = error?.response?.data || error?.data;
+                console.error("저장 실패:", error);
+                console.error("PocketBase details:", details);
+            } finally {
+                setIsSubmitting(false);
             }
         };
 


### PR DESCRIPTION
# PR 서식

- PR 이름 : 요리모임 작성 Autosave 도입 (/post/create)

- 수정한 이슈: 
   #42 
   #43 
   #44 

## 반영 브랜치
``` feature/post-autosave ```

## PR 유형

- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)

## PR 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] 문서에 해당 변경 사항을 업데이트 했습니다.
- [x] 해당 변경은 에러를 발생시키지 않았습니다.

### PR 상세(활동 및 수정사항)

- 새 훅 추가: src/hooks/usePostAutosave.js
   - 초안 저장/복원, 이탈 가드(popstate, 내부 링크 클릭, pushState/replaceState 래핑, beforeunload) 캡슐화
   - 완료 단계(step=8) 진입 시 가드 즉시 해제 + 로컬 초안 정리
   - 옵션화: draftKey, createPath, completeStep, confirmLeaveMsg, confirmResumeMsg
- 적용: PostCreate.jsx
   - 훅 호출 1줄 + 저장 성공 시 clearAutosave() 호출
   - PocketBase 전송 로직 안정화(FormData 빌더)
       - 숫자 필드 정규화(capacity, fee)
       - category는 JSON 문자열로 단일 append
       - 파일은 File만 append
       - 에러 상세 로그(error.response.data) 추가
- 관련 버그픽스
   - Header.jsx 단일 타이틀 버튼 분기에서 btn 미정의 참조 제거 #42 
   - Input.jsx 내부의 중첩 <form> 제거로 hydration 오류 방지  #43 

|임시저장 key 확인|임시저장된 글 불러오기|
|-----|-----|
|<img width="253" height="174" alt="스크린샷 2025-08-11 오후 4 21 36" src="https://github.com/user-attachments/assets/c8823194-e6ce-482e-88fa-02c1f5e418f9" />|<img width="526" height="187" alt="스크린샷 2025-08-11 오후 4 27 06" src="https://github.com/user-attachments/assets/04a205d1-a82d-4e61-85e5-1715c02f9e9d" />|
