### PR TITLE
React.lazy & Suspense 적용 + vendor 청크 세분화

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,13 +1,18 @@
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { Suspense, lazy } from "react";
 import { AuthProvider } from "./contexts/AuthContext";
-import Layout from './Layout';
-import Home from './pages/Home';
-import MyPage from './pages/MyPage';
-import Login from './pages/Login';
-import Register from './pages/Register';
-import RegisterSuccess from './pages/RegisterSuccess';
-import FindPassword from "./pages/FindPassword";
-import PostCreate from "./pages/PostCreate";
+import Layout from "./Layout";
+
+const Home = lazy(() => import("./pages/Home"));
+const MyPage = lazy(() => import("./pages/MyPage"));
+const Login = lazy(() => import("./pages/Login"));
+const Register = lazy(() => import("./pages/Register"));
+const RegisterSuccess = lazy(() => import("./pages/RegisterSuccess"));
+const FindPassword = lazy(() => import("./pages/FindPassword"));
+const PostCreate = lazy(() => import("./pages/PostCreate"));
+
+// 각 페이지 스켈레톤
+import PostCreateSkeleton from "./components/Skeletons/PostCreateSkeleton";
 
 function App() {
     return (
@@ -15,14 +20,64 @@ function App() {
             <AuthProvider>
                 <Routes>
                     <Route element={<Layout />}>
-                    <Route path="/" element={<Home />} />
-                    <Route path="/myPage" element={<MyPage />} />
-                    <Route path="/login" element={<Login />} />
-                    <Route path="/register" element={<Register />} />
-                    <Route path="/register/success" element={<RegisterSuccess />} />
-                    <Route path="/login/find-password" element={<FindPassword />} />
-                    <Route path="/post/create" element={<PostCreate />} />
-                </Route>
+                        <Route
+                            path="/"
+                            element={
+                                <Suspense fallback={null}>
+                                    <Home />
+                                </Suspense>
+                            }
+                        />
+                        <Route
+                            path="/myPage"
+                            element={
+                                <Suspense fallback={null}>
+                                    <MyPage />
+                                </Suspense>
+                            }
+                        />
+                        <Route
+                            path="/login"
+                            element={
+                                <Suspense fallback={null}>
+                                    <Login />
+                                </Suspense>
+                            }
+                        />
+                        <Route
+                            path="/register"
+                            element={
+                                <Suspense fallback={null}>
+                                    <Register />
+                                </Suspense>
+                            }
+                        />
+                        <Route
+                            path="/register/success"
+                            element={
+                                <Suspense fallback={null}>
+                                    <RegisterSuccess />
+                                </Suspense>
+                            }
+                        />
+                        <Route
+                            path="/login/find-password"
+                            element={
+                                <Suspense fallback={null}>
+                                    <FindPassword />
+                                </Suspense>
+                            }
+                        />
+                        <Route
+                            path="/post/create"
+                            element={
+                                // 이미 존재하는 PostCreateSkeleton 활용
+                                <Suspense fallback={<PostCreateSkeleton step={0} />}>
+                                    <PostCreate />
+                                </Suspense>
+                            }
+                        />
+                    </Route>
                 </Routes>
             </AuthProvider>
         </BrowserRouter>

--- a/src/pages/PostCreate.jsx
+++ b/src/pages/PostCreate.jsx
@@ -70,7 +70,6 @@ export default function PostCreate() {
         timeEnd: "",
         timeEndLabel: "",
         capacity: "2",
-        date: "",
         isFreeClass: false, // 무료 클래스
         fee: "10,000",
     });

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,18 +1,50 @@
-import { defineConfig } from 'vite';
+// vite.config.js
+import { defineConfig, splitVendorChunkPlugin } from 'vite';
 import react from '@vitejs/plugin-react';
-import tailwindcss from "tailwindcss";
+import tailwindcss from 'tailwindcss';
 import path from 'path';
 
 export default defineConfig({
-  plugins: [react()],
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src'),
+    plugins: [
+        react(),
+        // 기본 벤더 분할(그래프 기반) + 아래 manualChunks(명시 분할)를 함께 사용
+        splitVendorChunkPlugin(),
+    ],
+    resolve: {
+        alias: {
+            '@': path.resolve(__dirname, './src'),
+        },
     },
-  },
-  css: {
-    postcss: {
-      plugins: [tailwindcss()],
+    css: {
+        postcss: {
+            plugins: [tailwindcss()],
+        },
     },
-  },
+    build: {
+        rollupOptions: {
+            output: {
+                /**
+                 * 🧩 manualChunks:
+                 * - node_modules 안의 “무거운” 의존성을 개별 청크로 분리
+                 * - 나머지는 공통 'vendor'로 묶음
+                 * 필요에 따라 패키지를 추가/삭제하면 됨.
+                 */
+                manualChunks(id) {
+                    if (!id.includes('node_modules')) return;
+
+                    // 👇 자주 무거운 후보들
+                    if (id.includes('swiper')) return 'vendor-swiper';
+                    if (id.includes('framer-motion')) return 'vendor-framer';
+                    if (id.includes('react-hook-form')) return 'vendor-react-hook-form';
+                    if (id.includes('pocketbase')) return 'vendor-pocketbase';
+                    if (id.includes('/dayjs/')) return 'vendor-dayjs';
+                    if (id.includes('lucide-react')) return 'vendor-icons';
+                    if (id.includes('recharts')) return 'vendor-charts';
+
+                    // 공통 벤더(그 외)
+                    return 'vendor';
+                },
+            },
+        },
+    },
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -7,8 +7,7 @@ import path from 'path';
 export default defineConfig({
     plugins: [
         react(),
-        // 기본 벤더 분할(그래프 기반) + 아래 manualChunks(명시 분할)를 함께 사용
-        splitVendorChunkPlugin(),
+        splitVendorChunkPlugin(), // 자동 벤더 분할 보조
     ],
     resolve: {
         alias: {
@@ -24,24 +23,24 @@ export default defineConfig({
         rollupOptions: {
             output: {
                 /**
-                 * 🧩 manualChunks:
-                 * - node_modules 안의 “무거운” 의존성을 개별 청크로 분리
-                 * - 나머지는 공통 'vendor'로 묶음
-                 * 필요에 따라 패키지를 추가/삭제하면 됨.
+                 * manualChunks: 자주 쓰는 큰 의존성을 개별 청크로 분리
+                 * - 필요 없는 것은 지워도 됨(프로젝트 사용 라이브러리만 남기기)
                  */
                 manualChunks(id) {
                     if (!id.includes('node_modules')) return;
 
-                    // 👇 자주 무거운 후보들
+                    // 리액트 코어
+                    if (id.includes('/react-dom')) return 'vendor-react-dom';
+                    if (id.includes('/react/')) return 'vendor-react';
+
+                    // 프로젝트에서 무거운 것들
                     if (id.includes('swiper')) return 'vendor-swiper';
-                    if (id.includes('framer-motion')) return 'vendor-framer';
-                    if (id.includes('react-hook-form')) return 'vendor-react-hook-form';
                     if (id.includes('pocketbase')) return 'vendor-pocketbase';
+                    if (id.includes('framer-motion')) return 'vendor-framer';
                     if (id.includes('/dayjs/')) return 'vendor-dayjs';
                     if (id.includes('lucide-react')) return 'vendor-icons';
-                    if (id.includes('recharts')) return 'vendor-charts';
 
-                    // 공통 벤더(그 외)
+                    // 그 외 공통
                     return 'vendor';
                 },
             },


### PR DESCRIPTION
# PR 서식

- PR 이름 : React.lazy & Suspense 적용 – 라우트 단위 코드 스플리팅

- 수정한 이슈 : 
     #49 
     #50

## 반영 브랜치
refactor/react-lazy-suspense`

## PR 유형
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링

## PR 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] 문서에 해당 변경 사항을 업데이트 했습니다.
- [x] 해당 변경은 에러를 발생시키지 않았습니다.

### PR 상세(활동 및 수정사항)

### 1️⃣ React.lazy & Suspense 적용
- **React.lazy**와 **Suspense**를 적용하여 페이지 단위 코드 스플리팅 구현
- **라우트별 청크 분리**
  - `Home-*.js`, `Login-*.js`, `MyPage-*.js`, `Register-*.js`, `FindPassword-*.js`, `RegisterSuccess-*.js`, `PostCreate-*.js` 등 개별 파일 생성
- **초기 번들 크기 감소**
  - 변경 전: `index-D7DGYXO7.js` → **422.99 KB** (gzip **128.11 KB**)
  - 변경 후: `index-BGfVSCBp.js` → **282.60 KB** (gzip **87.75 KB**)
  - 감소량: 약 **140.4 KB (-33.2%)**, gzip 기준 **40.4 KB (-31.5%)**
- **무거운 페이지(PostCreate) 분리**
  - `PostCreate-*.js`: **113.41 KB** (gzip **34.59 KB**) → 초기 로드에서 제외
- **CSS도 페이지별 분리**
  - `PostCreate-*.css` 생성 → 해당 페이지 진입 시에만 로드
 - **코드 품질 개선**
  - `PostCreate.jsx`에서 **`date` 필드 중복 선언 제거** → 빌드 경고 해결

### lazy 변경 전/후 
| "/" lazy 적용 전 | "/" lazy 적용 후 |
|-----|-----|
|<img width="394" height="247" alt="스크린샷 2025-08-13 오후 9 30 34" src="https://github.com/user-attachments/assets/2c4b078a-d994-4c19-a439-4ff961c778ee" />|<img width="375" height="249" alt="스크린샷 2025-08-13 오후 9 30 55" src="https://github.com/user-attachments/assets/32ccaec9-12ad-426a-9f6c-cdc2b41b1e01" />|

| "/myPage" lazy 적용 전 | "/myPage" lazy 적용 후 |
|-----|-----|
|<img width="403" height="252" alt="스크린샷 2025-08-13 오후 9 31 32" src="https://github.com/user-attachments/assets/d3827fb5-8e6f-4846-9270-4ad0fe7f647a" />|<img width="378" height="222" alt="스크린샷 2025-08-13 오후 9 31 40" src="https://github.com/user-attachments/assets/e049eaf8-3682-499e-be78-c20e59dbe712" />|

| "/post/create" lazy 적용 전 | "/post/create" lazy 적용 후 |
|-----|-----|
|<img width="383" height="233" alt="스크린샷 2025-08-13 오후 9 34 20" src="https://github.com/user-attachments/assets/8ec64af4-4110-41e3-b1f1-063baa39507a" />|<img width="387" height="227" alt="스크린샷 2025-08-13 오후 9 34 32" src="https://github.com/user-attachments/assets/bb0014cf-a187-43e9-86d8-8bf98c91fe07" />|

---

### 2️⃣ vendor 청크 세분화 – 캐시 효율 및 분석 용이성 향상
- manualChunks 설정으로 주요 라이브러리 개별 청크 분리
   - vendor-react, vendor-react-dom, vendor-swiper, vendor-pocketbase 등으로 분할
- 효과
   - 브라우저 캐시 재사용성 증가 (특정 라이브러리 업데이트 시 전체 vendor 재빌드 방지)
   - 번들 분석 시 의존성별 크기 파악 용이
- 예시 (gzip 크기 기준):
   - vendor-react-dom → 54.54 KB
   - vendor-swiper → 25.28 KB
   - vendor-pocketbase → 10.69 KB
   - vendor-react → 3.28 KB
   - 기타 vendor → 15.96 KB

### 변경 전/후 비교

| 구분 | 변경 전 | 변경 후 |
|------|--------|--------|
| **vendor.js 용량(비gzip)** | 225.03 KB | — (분리됨) |
| **최대 단일 vendor(gzip)** | 72.90 KB | 54.54 KB |
| **청크 개수** | 1개 (vendor) | 6개 (vendor-react, vendor-react-dom, vendor-swiper, vendor-pocketbase, vendor-etc, vendor-css) |

### 변경 후 주요 청크 현황

| 청크명 | 비gzip | gzip | 비고 |
|--------|--------|------|------|
| `vendor-react-dom` | 173.70 KB | **54.54 KB** | React 렌더링 엔진, 가장 큰 청크 |
| `vendor-swiper` | 82.14 KB | 25.28 KB | 슬라이더 라이브러리 |
| `vendor-pocketbase` | 37.71 KB | 10.69 KB | 백엔드 API SDK |
| `vendor-react` | 8.67 KB | 3.28 KB | React core |
| `vendor-DJrikFEs` | 41.99 KB | 15.96 KB | 기타 라이브러리 |
| `vendor-swiper.css` | 6.39 KB | 2.85 KB | Swiper 스타일 |

---

### 예정 작업
- 추후 `<Suspense>` fallback에 페이지별 스켈레톤 UI 적용 예정 - 현재는 "/post"에만 적용 함
