### PR TITLE
feat: 프로필 편집 플로우 정리 — 탈퇴 기능, 가입 직후 버그 픽스, 주소 표시 UX 개선

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,7 @@ const PostCreate = lazy(() => import("./pages/PostCreate"));
 const MyPosts = lazy(() => import("./pages/MyPosts"));
 const PostDetail = lazy(() => import("./pages/PostDetail"));
 const PostEdit = lazy(() => import("./pages/PostEdit"));
+const MyInfoEdit = lazy(() => import("./pages/MyInfoEdit"));
 
 // 각 페이지 스켈레톤
 import PostCreateSkeleton from "./components/Skeletons/PostCreateSkeleton";
@@ -78,6 +79,10 @@ function App() {
                                     <MyPage />
                                 </Suspense>
                             }
+                        />
+                        <Route 
+                            path="/mypage/edit" 
+                            element={<MyInfoEdit />} 
                         />
                         <Route
                             path="/login"

--- a/src/lib/NavItems.js
+++ b/src/lib/NavItems.js
@@ -304,6 +304,44 @@ export function useNavItems() {
                 },
             },
 
+            {
+                to: "/mypage/edit",
+                label: "내 정보 수정",
+                showInNav: false,
+                header: {
+                    byScreen: {
+                        mobile: {
+                            showLogo: false,
+                            showHamburger: false,
+                            showBack: true,
+                            showNav: false,
+                            showTitle: true,
+                            Icon2Name: null,
+                            showProfile: false,
+                        },
+                        tablet: {
+                            showLogo: false,
+                            showHamburger: false,
+                            showBack: true,
+                            showNav: false,
+                            showTitle: true,
+                            Icon2Name: null,
+                            showProfile: false,
+                        },
+                        desktop: {
+                            showLogo: true,
+                            showHamburger: false,
+                            showBack: false,
+                            showNav: false,
+                            showTitle: false,
+                            Icon2Name: null,
+                            showButtonTitle: ({ user }) => !user,
+                            showProfile: false,
+                        },
+                    },
+                },
+            },
+
             // 모임 등록하기
             {
                 to: createTo,

--- a/src/lib/deleteAccountWithConfirm.js
+++ b/src/lib/deleteAccountWithConfirm.js
@@ -1,0 +1,139 @@
+// src/lib/deleteAccountWithConfirm.js
+import pb from "./pocketbase";
+
+const SUBMIT_SKELETON_MIN_MS = Number(import.meta.env.VITE_SUBMIT_SKELETON_MIN_MS || 600);
+
+/**
+ * 계정 삭제(탈퇴) 유틸 - 관련 레코드(게시글/임시저장 등) 먼저 삭제 후 계정 삭제
+ *
+ * @param {string} userId                            // 현재 탈퇴 대상 유저 id
+ * @param {object} opts
+ * @param {(o:{title?:string,description?:string,confirmText?:string,cancelText?:string,tone?:'default'|'danger'})=>Promise<boolean>} [opts.confirm]
+ * @param {(msg:string, o?:{tone?:'success'|'error'})=>void} [opts.notify]
+ * @param {Function} [opts.before]                   // 네트워크 전
+ * @param {Function} [opts.after]                    // 스켈레톤 최소 노출 보장 후
+ * @param {Function} [opts.onSuccess]                // 전부 성공 시
+ * @param {(err:any)=>void} [opts.onError]           // 실패 시
+ * @param {(path:string, o?:{replace?:boolean})=>void} [opts.navigate] // react-router navigate
+ *
+ * @param {Array<{name:string, ownerField?:string, filter?:string}>} [opts.collections]
+ *   - 삭제할 관련 컬렉션 목록
+ *   - ownerField: 기본은 "editor" (해당 필드가 userId인 레코드 삭제)
+ *   - filter: 직접 필터 문자열을 주면 ownerField 대신 사용됨
+ *
+ * 기본 컬렉션:
+ *   post(작성글), post_draft(임시저장) 를 대상으로 함
+ */
+export async function deleteAccountWithConfirm(userId, opts = {}) {
+    const {
+        confirm,
+        notify,
+        before,
+        after,
+        onSuccess,
+        onError,
+        navigate,
+        collections = [
+            { name: "post", ownerField: "editor" },
+            { name: "post_draft", ownerField: "editor" }, // 임시저장 컬렉션 이름이 다르면 이 배열만 교체하면 됩니다.
+        ],
+    } = opts;
+
+    const start = Date.now();
+
+    try {
+        // 1) 확인 모달
+        let ok = true;
+        if (typeof confirm === "function") {
+            ok = await confirm({
+                title: "정말 탈퇴하시겠습니까?",
+                description: "작성하신 게시글, 임시저장 등 모든 데이터가 삭제되며 되돌릴 수 없습니다.",
+                confirmText: "탈퇴",
+                cancelText: "취소",
+                tone: "danger",
+            });
+        } else {
+            ok = window.confirm("정말 탈퇴하시겠습니까?");
+        }
+        if (!ok) return;
+
+        before?.();
+
+        // 2) 관련 레코드 일괄 삭제
+        const deleteAllWhere = async (col, filter, pageSize = 50) => {
+            let page = 1;
+            // 페이지를 앞으로 읽어오면서 삭제. 삭제에 따라 nextPage 개념이 흔들릴 수 있어 루프 재조회.
+            // 안전하게 더 이상 항목이 없을 때까지 반복.
+            // (PocketBase getList는 {page, perPage, totalItems} 응답)
+            // 필터 예: `editor="USER_ID"`
+            // 주의: 컬렉션 규칙에 따라 권한 필요.
+            // 실패는 throw 하여 상위 catch로 전달.
+            for (;;) {
+                const res = await pb.collection(col).getList(page, pageSize, { filter });
+                const items = Array.isArray(res?.items) ? res.items : [];
+                if (items.length === 0) break;
+
+                // 병렬 삭제(실패한 항목은 로깅)
+                const results = await Promise.allSettled(items.map(it => pb.collection(col).delete(it.id)));
+                const failed = results.filter(r => r.status === "rejected");
+                if (failed.length > 0) {
+                    // 규칙/권한 문제로 일부 남을 수 있음 — 에러를 올려서 전체 프로세스를 중단하는 편을 택함
+                    throw new Error(`[${col}] 일부 레코드 삭제 실패 (${failed.length}건)`);
+                }
+
+                // 다음 페이지로 진행
+                page += 1;
+            }
+        };
+
+        // 사용자 소유 레코드 삭제 루프
+        for (const c of collections) {
+            const name = c?.name;
+            if (!name) continue;
+
+            const filter =
+                typeof c?.filter === "string" && c.filter.trim().length > 0
+                    ? c.filter
+                    : `${c?.ownerField ?? "editor"} = "${userId}"`;
+
+            try {
+                await deleteAllWhere(name, filter);
+            } catch (err) {
+                console.error(`[deleteAccount] ${name} 삭제 중 오류:`, err);
+                throw err; // 전체 중단
+            }
+        }
+
+        // 3) 계정 삭제
+        await pb.collection("users").delete(userId);
+
+        // 4) 인증 해제 & 홈으로 이동
+        try {
+            pb.authStore?.clear?.();
+        } catch (_) {}
+        if (typeof notify === "function") {
+            notify("탈퇴가 완료되었습니다.", { tone: "success" });
+        }
+        onSuccess?.();
+
+        if (typeof navigate === "function") {
+            navigate("/", { replace: true });
+        } else {
+            // 라우터 navigate가 없으면 하드 리다이렉트(보조)
+            window.location.assign("/");
+        }
+    } catch (error) {
+        const details = error?.response?.data || error?.data;
+        console.error("탈퇴 실패:", error);
+        console.error("PocketBase details:", details);
+
+        if (typeof notify === "function") {
+            notify("탈퇴 처리 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.", { tone: "error" });
+        }
+        onError?.(error);
+    } finally {
+        const elapsed = Date.now() - start;
+        const remain = Math.max(0, SUBMIT_SKELETON_MIN_MS - elapsed);
+        setTimeout(() => after?.(), remain);
+    }
+}

--- a/src/pages/MyInfoEdit.jsx
+++ b/src/pages/MyInfoEdit.jsx
@@ -1,0 +1,260 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import pb from "../lib/pocketbase";
+import { useAuth } from "../contexts/AuthContext";
+import { useConfirm } from "../components/Modal/ConfirmProvider";
+import PageTitleBar from "../components/PageTitleBar/PageTitleBar";
+import Input from "../components/Input/Input";
+import CustomButton from "../components/CustomButton/CustomButton";
+import SelectImageGroup from "../components/SelectImageGroup/SelectImageGroup";
+import useProfileImages from "../hooks/useProfileImages";
+import getPbImageURL from "../lib/getPbImageURL";
+
+const SUBMIT_SKELETON_MIN_MS = Number(import.meta.env.VITE_SUBMIT_SKELETON_MIN_MS || 600);
+
+export default function MyInfoEdit() {
+    const navigate = useNavigate();
+    const confirm = useConfirm();
+    const { user: authUser, refresh: refreshAuth } = useAuth();
+
+    // 가드: 비로그인 → 로그인으로
+    useEffect(() => {
+        if (!authUser?.id) {
+            navigate("/login", { replace: true });
+        }
+    }, [authUser, navigate]);
+
+    const [nickname, setNickname] = useState(authUser?.nickname ?? "");
+    const [checking, setChecking] = useState({ nickname: null }); // null|true|false
+    const [isSubmitting, setIsSubmitting] = useState(false);
+
+    // 프로필 이미지 업로드(회원가입과 동일 패턴)
+    // - 최대 1장
+    const { images, clearImages, handleAddImage, handleRemoveImage } = useProfileImages(1);
+    // 기본 이미지/선택 이미지 라디오
+    const [selectedValue, setSelectedValue] = useState(
+        authUser?.images ? "checked" : "default"
+    );
+
+    // 유효성
+    const nicknameValid = useMemo(() => /^[a-zA-Z0-9가-힣]{1,5}$/.test(nickname), [nickname]);
+    const canSubmit = useMemo(() => {
+        // 닉네임 형식 OK 이고, 중복체크 통과(또는 내 닉 그대로) 이고,
+        // 이미지 정책(기본/선택)도 충족
+        const imageOk = selectedValue === "default" || images.length > 0;
+        const nicknameOwn = nickname === (authUser?.nickname ?? "");
+        const nicknameReady = nicknameOwn || checking.nickname === true; // 내 닉이면 체크 불필요
+        return nicknameValid && nicknameReady && imageOk && !!authUser?.id && !isSubmitting;
+    }, [nickname, nicknameValid, checking.nickname, selectedValue, images.length, authUser?.id, authUser?.nickname, isSubmitting]);
+
+    // 닉네임 중복확인 (본인 제외)
+    const handleNicknameCheck = async () => {
+        if (!nicknameValid || !authUser?.id) return;
+        setChecking((p) => ({ ...p, nickname: null }));
+        try {
+            // 본인(id) 제외하고 같은 닉이 있으면 중복
+            await pb.collection("users").getFirstListItem(`nickname="${nickname}" && id != "${authUser.id}"`);
+            setChecking((p) => ({ ...p, nickname: false }));
+        } catch {
+            setChecking((p) => ({ ...p, nickname: true }));
+        }
+    };
+
+    // 저장
+    const handleSave = async () => {
+        if (!canSubmit) return;
+
+        const start = Date.now();
+        setIsSubmitting(true);
+
+        try {
+            const data = new FormData();
+            data.append("nickname", nickname);
+
+            if (selectedValue === "default") {
+                // 파일 필드 비우기(PB는 빈 문자열로 클리어)
+                data.append("images", "");
+            } else {
+                // 새 파일이 있을 때만 덮어씀(없으면 기존 유지)
+                images.forEach((file) => {
+                    if (file instanceof File) {
+                        data.append("images", file);
+                    }
+                });
+            }
+
+            await pb.collection("users").update(authUser.id, data);
+            // 내 세션 최신화
+            await refreshAuth?.();
+
+            const elapsed = Date.now() - start;
+            const remain = Math.max(0, SUBMIT_SKELETON_MIN_MS - elapsed);
+            setTimeout(async () => {
+                setIsSubmitting(false);
+                await confirm({
+                    title: "완료",
+                    description: "변경사항이 저장되었습니다.",
+                    confirmText: "확인",
+                    cancelText: "",
+                });
+                navigate(`/mypage/${authUser.id}`, { replace: true });
+            }, remain);
+        } catch (error) {
+            const details = error?.response?.data || error?.data;
+            console.error("프로필 저장 실패:", error);
+            console.error("PocketBase details:", details);
+
+            const elapsed = Date.now() - start;
+            const remain = Math.max(0, SUBMIT_SKELETON_MIN_MS - elapsed);
+            setTimeout(async () => {
+                setIsSubmitting(false);
+                await confirm({
+                    title: "오류",
+                    description: "저장에 실패했습니다. 잠시 후 다시 시도해 주세요.",
+                    confirmText: "확인",
+                });
+            }, remain);
+        }
+    };
+
+    // 입력 컴포넌트 상태 텍스트(회원가입과 동일 톤)
+    const nicknameSubTexts = (() => {
+        const arr = [];
+        if (!nickname) {
+            arr.push({ text: "특수문자를 제외한 5자 이내로 작성해 주세요.", type: "info" });
+            return arr;
+        }
+        if (!nicknameValid) {
+            arr.push({ text: "특수문자를 제외한 5자 이내로 작성해 주세요.", type: "error" });
+            return arr;
+        }
+        if (nickname === (authUser?.nickname ?? "")) {
+            arr.push({ text: "현재 사용 중인 닉네임입니다.", type: "info" });
+            return arr;
+        }
+        if (checking.nickname === true) {
+            arr.push({ text: "사용 가능한 닉네임입니다.", type: "finish" });
+            return arr;
+        }
+        if (checking.nickname === false) {
+            arr.push({ text: "이미 사용 중인 닉네임입니다.", type: "error" });
+            return arr;
+        }
+        arr.push({ text: "중복확인을 진행해 주세요.", type: "info" });
+        return arr;
+    })();
+
+    const nicknameInputState =
+        !nickname
+            ? "default"
+            : !nicknameValid
+            ? "error"
+            : checking.nickname === false
+            ? "error"
+            : "default";
+
+    const nicknameButtonState =
+        !nicknameValid || !nickname || nickname === (authUser?.nickname ?? "")
+            ? "disable"
+            : checking.nickname === true
+            ? "disable"
+            : "activation";
+
+    // 기존 등록된 프로필 이미지 URL (있으면 미리보기로 쓰기)
+    const existingImageUrl = useMemo(() => {
+        if (authUser?.images) {
+            try {
+                return getPbImageURL(authUser, "images");
+            } catch {
+                return null;
+            }
+        }
+        return null;
+    }, [authUser]);
+
+    // A) 처음 한 번만 기존 이미지를 미리보기로 채워 넣기(삭제 후 다시 채워지는 문제 방지)
+    const hydratedOnceRef = useRef(false);
+    useEffect(() => {
+        if (hydratedOnceRef.current) return;
+        if (selectedValue === "checked" && existingImageUrl && images.length === 0) {
+            (async () => {
+                try {
+                    const res = await fetch(existingImageUrl, { cache: "no-cache" });
+                    const blob = await res.blob();
+                    const ext = (blob.type && blob.type.split("/")[1]) || "jpg";
+                    const file = new File([blob], `current-profile.${ext}`, { type: blob.type || "image/jpeg" });
+                    handleAddImage(file);
+                    hydratedOnceRef.current = true;
+                } catch (e) {
+                    console.error("기존 프로필 이미지 로드 실패:", e);
+                }
+            })();
+        }
+    }, [selectedValue, existingImageUrl, images.length, handleAddImage]);
+    
+    // B) '기본 이미지'로 바꾸면 업로드 목록은 비웁니다(헷갈림 방지)
+    useEffect(() => {
+        if (selectedValue === "default" && images.length > 0) {
+            clearImages();
+        }
+    }, [selectedValue, images.length, clearImages]);
+
+    return (
+        <>
+            <PageTitleBar />
+
+            <div className="
+                max-w-[500px] mx-auto mt-8 mb-8
+                px-4 tablet:px-0 desktop:px-0
+            ">
+                <div className="flex flex-col gap-3">
+                    <Input
+                        label="닉네임"
+                        type="text"
+                        placeholder="닉네임을 입력해주세요."
+                        value={nickname}
+                        onChange={(e) => {
+                            setNickname(e.target.value);
+                            // 닉네임 타이핑 시 중복 상태 리셋
+                            setChecking((p) => ({ ...p, nickname: null }));
+                        }}
+                        state={nicknameInputState}
+                        buttontext="중복확인"
+                        buttonState={nicknameButtonState}
+                        onButtonClick={handleNicknameCheck}
+                        subTexts={nicknameSubTexts}
+                    />
+
+                    <SelectImageGroup
+                        title="프로필 이미지"
+                        selectedValue={selectedValue}
+                        onChangeValue={(value) => {
+                            clearImages();
+                            setSelectedValue(value);
+                        }}
+                        images={images}
+                        onAddImage={handleAddImage}
+                        onRemoveImage={handleRemoveImage}
+                        radioOptions={[
+                            { value: "default", label: "기본 이미지" },
+                            { value: "checked", label: "선택 이미지" },
+                        ]}
+                        state="default"
+                        className="mb-6"
+                        maxCount={1}
+                    />
+
+                    <div className="flex gap-2">
+                        <CustomButton
+                            text="적용하기"
+                            variant="primary"
+                            size="lg"
+                            state={canSubmit ? "default" : "disable"}
+                            onClick={handleSave}
+                        />
+                    </div>
+                </div>
+            </div>
+        </>
+    );
+}

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -212,14 +212,16 @@ export default function MyPage() {
 
                         {/* 내 페이지일 때만 편집 버튼/로그인 유도 버튼 */}
                         {isOwnPage && authUser ? (
-                            <CustomButton
-                                text="내 정보 수정"
-                                variant="secondary"
-                                size="sm"
-                                custombuttonClass="!w-fit"
-                                basebuttonClass="hover:bg-[var(--color-gray-3)]"
-                                onClick={handleEditProfile}
-                            />
+                            <Link to="/mypage/edit" className="inline-block" title="/mypage/edit">
+                                <CustomButton
+                                    text="내 정보 수정"
+                                    variant="secondary"
+                                    size="sm"
+                                    custombuttonClass="!w-fit"
+                                    basebuttonClass="hover:bg-[var(--color-gray-3)]"
+                                    onClick={undefined} // 링크로 이동하므로 클릭 핸들러 비활성화
+                                />
+                            </Link>
                         ) : isOwnPage && !authUser ? (
                             <CustomButton
                                 text="회원가입/로그인"

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -11,6 +11,12 @@ import SvgIcon from "../components/SvgIcon/SvgIcon";
 import DarkModeToggle from "../components/DarkModeToggle/DarkModeToggle";
 import UserName from "../components/User/UserName";
 import MyPageSkeleton from "../components/Skeletons/MyPageSkeleton";
+import { useConfirm } from "../components/Modal/ConfirmProvider";
+
+// 탈퇴 시 소유 데이터 정리 대상(필요 시 컬렉션 추가)
+const COLLECTIONS_TO_CLEAN = [
+    { name: "post", ownerField: "editor" },
+];
 
 export default function MyPage() {
     const navigate = useNavigate();
@@ -24,33 +30,54 @@ export default function MyPage() {
     const { dataLoading } = useFetchFiles("files", 1, 50);
     const showSkeleton = dataLoading || isSubmitting;
 
+    // 현재 페이지가 내 페이지인지 판별(파라미터가 없거나 내 id와 같으면 true)
     const isOwnPage = !userId || userId === authUser?.id;
+
+    const confirm = useConfirm();
 
     useEffect(() => {
         let cancelled = false;
 
-        const run = async () => {
-            try {
-                setIsSubmitting(true);
+        // [Step 0] 탈퇴/로그아웃 직후: URL에 남은 삭제된 userId로 API를 치지 않도록 즉시 홈으로
+        if (!authUser && userId) {
+            navigate("/", { replace: true });
+            return;
+        }
 
-                if (isOwnPage) {
-                    setProfileUser(authUser ?? null);
-                } else {
-                    const u = await pb.collection("users").getOne(userId);
-                    if (!cancelled) setProfileUser(u);
+        // [Step 1] 내 페이지라면 서버 호출 없이 세션의 authUser로 즉시 렌더(빠르고 안전)
+        if (!userId || (authUser?.id && userId === authUser.id)) {
+            setProfileUser(authUser ?? null);
+            // setViewedUser(authUser ?? null);  // (동시에 쓰는 곳이 있다면 주석 해제)
+            return;
+        }
+
+        // [Step 2] 다른 유저 페이지일 때만 서버에서 사용자 조회
+        const run = async () => {
+            setIsSubmitting(true);
+            try {
+                const rec = await pb.collection("users").getOne(userId);
+                if (cancelled) return;
+                setProfileUser(rec);
+                // setViewedUser(rec);  // (동시에 쓰는 곳이 있다면 주석 해제)
+            } catch (err) {
+                if (!cancelled) {
+                    if (err?.status === 404) {
+                        // [핵심] 삭제된/없는 유저는 콘솔 소음 없이 홈으로 리다이렉트
+                        navigate("/", { replace: true });
+                    } else {
+                        console.error("MyPage user load failed:", err);
+                        setProfileUser(null);
+                    }
                 }
-            } catch {
-                if (!cancelled) setProfileUser(null);
             } finally {
                 if (!cancelled) setIsSubmitting(false);
             }
         };
 
         run();
-        return () => {
-            cancelled = true;
-        };
-    }, [userId, authUser, isOwnPage]);
+        return () => { cancelled = true; };
+    }, [userId, authUser?.id, navigate]);
+
 
     const textClasses = {
         title:
@@ -61,6 +88,93 @@ export default function MyPage() {
 
     const handleEditProfile = () => {
         navigate("/mypage/edit");
+    };
+
+    // --- 탈퇴 유틸들 (필요 최소만 추가) ---
+
+    // [Util A] 컬렉션이 없거나 권한으로 감춰진 경우 404를 조용히 무시하고 빈 배열 반환
+    async function safeFullList(pbClient, name, filter) {
+        try {
+            return await pbClient.collection(name).getFullList({ filter });
+        } catch (e) {
+            if (e?.status === 404) return []; // Missing collection / Hidden
+            throw e;
+        }
+    }
+
+    // [Util B] 유저 소유 레코드 일괄 삭제(대량 삭제 시 chunk로 병렬 처리)
+    async function deleteOwnedRecords(pbClient, ownerId) {
+        for (const { name, ownerField } of COLLECTIONS_TO_CLEAN) {
+            try {
+                const items = await safeFullList(
+                    pbClient,
+                    name,
+                    `${ownerField} = "${ownerId}"`
+                );
+                const chunk = 10;
+                for (let i = 0; i < items.length; i += chunk) {
+                    await Promise.allSettled(
+                        items
+                            .slice(i, i + chunk)
+                            .map((rec) => pbClient.collection(name).delete(rec.id))
+                    );
+                }
+            } catch (err) {
+                // 네트워크 등 진짜 오류만 로깅하고 계속 진행
+                console.error(`[탈퇴] ${name} 정리 실패`, err);
+            }
+        }
+    }
+
+    // [Util C] 로컬스토리지 흔적 정리(draft:* 등 임시 데이터/사용자 캐시 제거)
+    function clearLocalFootprints() {
+        try {
+            const removeKeys = new Set(["draft:post", "userId"]);
+            for (let i = 0; i < localStorage.length; i++) {
+                const k = localStorage.key(i);
+                if (k && k.startsWith("draft:")) removeKeys.add(k);
+            }
+            [...removeKeys].forEach((k) => localStorage.removeItem(k));
+        } catch (e) {
+            console.warn("localStorage clear failed:", e);
+        }
+    }
+
+    // [Action] 탈퇴 플로우(확인 → 소유 데이터 정리 → 계정 삭제 → 세션/로컬 정리 → 홈 이동)
+    const handleDeleteAccount = async () => {
+        if (!authUser) return;
+
+        const ok = await confirm({
+            title: "정말 탈퇴하시겠습니까?",
+            description: "계정 삭제 후에는 복구할 수 없습니다.",
+            confirmText: "탈퇴",
+            cancelText: "취소",
+            tone: "danger",
+        });
+        if (!ok) return;
+
+        try {
+            setIsSubmitting(true);
+
+            // 1) 서버에서 내가 만든 데이터 정리
+            await deleteOwnedRecords(pb, authUser.id);
+
+            // 2) 계정 삭제
+            await pb.collection("users").delete(authUser.id);
+
+            // 3) 세션/로컬 흔적 정리
+            clearLocalFootprints();    // draft:* , userId 등 제거
+            logout();                  // pocketbase_auth 세션 제거
+
+            // 4) 홈으로
+            navigate("/", { replace: true });
+        } catch (error) {
+            const details = error?.response?.data || error?.data;
+            console.error("탈퇴 실패:", error);
+            console.error("PocketBase details:", details);
+        } finally {
+            setIsSubmitting(false);
+        }
     };
 
     return (
@@ -77,6 +191,7 @@ export default function MyPage() {
                         desktop:px-0
                     "
                 >
+                    {/* 상단 프로필 영역 */}
                     <div className="mb-4 flex flex-col gap-2 items-center">
                         <ProfileAvatar
                             user={profileUser}
@@ -95,6 +210,7 @@ export default function MyPage() {
                             <p className="text-[var(--color-gray-6)]">유저를 찾을 수 없습니다</p>
                         )}
 
+                        {/* 내 페이지일 때만 편집 버튼/로그인 유도 버튼 */}
                         {isOwnPage && authUser ? (
                             <CustomButton
                                 text="내 정보 수정"
@@ -102,7 +218,7 @@ export default function MyPage() {
                                 size="sm"
                                 custombuttonClass="!w-fit"
                                 basebuttonClass="hover:bg-[var(--color-gray-3)]"
-                                onClick={handleEditProfile}  // "/mypage/edit" 이동
+                                onClick={handleEditProfile}
                             />
                         ) : isOwnPage && !authUser ? (
                             <CustomButton
@@ -117,8 +233,10 @@ export default function MyPage() {
                         ) : null}
                     </div>
 
+                    {/* 하단 섹션들 */}
                     {profileUser ? (
                         <div className="flex flex-col gap-3">
+                            {/* 활동 모아보기 */}
                             <ul className="bg-[var(--color-gray-1)] px-3 pt-3 pb-1 rounded-lg">
                                 <li className="mb-2">
                                     <b className={textClasses.title}>활동 모아보기</b>
@@ -158,6 +276,7 @@ export default function MyPage() {
                                 )}
                             </ul>
 
+                            {/* 환경 설정: 다크모드 */}
                             {isOwnPage && authUser && (
                                 <ul className="bg-[var(--color-gray-1)] p-3 rounded-lg">
                                     <li className="mb-2">
@@ -169,6 +288,7 @@ export default function MyPage() {
                                 </ul>
                             )}
 
+                            {/* 계정 영역: 로그아웃/탈퇴 */}
                             {isOwnPage && authUser && (
                                 <ul className="bg-[var(--color-gray-1)] p-3 rounded-lg">
                                     <li className="py-1">
@@ -183,7 +303,10 @@ export default function MyPage() {
                                         </b>
                                     </li>
                                     <li className="py-1">
-                                        <b className={`cursor-pointer hover:text-[var(--color-gray-7)] transition ${textClasses.title}`}>
+                                        <b
+                                            className={`cursor-pointer hover:text-[var(--color-gray-7)] transition ${textClasses.title}`}
+                                            onClick={handleDeleteAccount}
+                                        >
                                             탈퇴 하기
                                         </b>
                                     </li>

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -59,6 +59,10 @@ export default function MyPage() {
             "font-bold text-mo-title tablet:text-tab-title desktop:text-pc-title text-[var(--color-gray-8)] hover:text-[var(--color-gray-6)] py-1 transition",
     };
 
+    const handleEditProfile = () => {
+        navigate("/mypage/edit");
+    };
+
     return (
         <>
             {showSkeleton ? (
@@ -97,6 +101,8 @@ export default function MyPage() {
                                 variant="secondary"
                                 size="sm"
                                 custombuttonClass="!w-fit"
+                                basebuttonClass="hover:bg-[var(--color-gray-3)]"
+                                onClick={handleEditProfile}  // "/mypage/edit" 이동
                             />
                         ) : isOwnPage && !authUser ? (
                             <CustomButton

--- a/src/pages/MyPosts.jsx
+++ b/src/pages/MyPosts.jsx
@@ -10,9 +10,9 @@ import { deletePostWithConfirm } from "../lib/deletePostWithConfirm";
 import PageTitleBar from "../components/PageTitleBar/PageTitleBar";
 import PostCardSkeleton from "../components/Skeletons/PostCardSkeleton";
 import CustomButton from "../components/CustomButton/CustomButton";
+import PostCardCompact from "../components/PostCard/PostCardCompact";
 
 const SUBMIT_SKELETON_MIN_MS = Number(import.meta.env.VITE_SUBMIT_SKELETON_MIN_MS || 1000);
-import PostCardCompact from '../components/PostCard/PostCardCompact';
 
 export default function MyPosts() {
     const navigate = useNavigate();
@@ -20,16 +20,15 @@ export default function MyPosts() {
     const { userId: paramUserId } = useParams();
 
     // 보고 있는 대상 유저 id: 파라미터 우선, 없으면 로그인 유저
-    const viewedUserId = paramUserId ?? user?.id ?? null;
+    const viewedUserId = paramUserId ?? authUser?.id ?? null;
 
-    const [viewedUser, setViewedUser] = useState(null);   // 작성자 레코드(모든 카드에 공통 주입)
+    const [viewedUser, setViewedUser] = useState(null);
     const [userPosts, setUserPosts] = useState([]);
     const [isSubmitting, setIsSubmitting] = useState(false);
     const { dataLoading } = useFetchFiles("files", 1, 50);
     const showSkeleton = dataLoading || isSubmitting;
     const confirm = useConfirm();
 
-    // 대상 유저의 프로필 1회 조회 (author로 사용)
     useEffect(() => {
         let cancelled = false;
         const run = async () => {
@@ -46,7 +45,6 @@ export default function MyPosts() {
         return () => { cancelled = true; };
     }, [viewedUserId]);
 
-    // 게시물 삭제 (목록에서)
     const handleDeleteInList = useCallback((postId) => {
         deletePostWithConfirm(postId, {
             confirm,
@@ -59,37 +57,20 @@ export default function MyPosts() {
         });
     }, [navigate, viewedUserId, confirm]);
 
-    // 게시물 수정 (목록에서)
     const handleEditInList = useCallback((postId) => {
         navigate(`/post/edit/${postId}`);
     }, [navigate]);
 
-    // post:updated 이벤트 수신 → 리스트 항목 갱신
-    useEffect(() => {
-        const onUpdated = (e) => {
-            const rec = e.detail;
-            if (!rec?.id) return;
-            setUserPosts(prev => prev.map(p => (p.id === rec.id ? rec : p)));
-        };
-        window.addEventListener("post:updated", onUpdated);
-        return () => window.removeEventListener("post:updated", onUpdated);
-    }, []);
-
-    // 대상 유저의 게시물 가져오기 (옵션 최소화 → 400 회피)
     useEffect(() => {
         if (!viewedUserId) return;
-    
+
         let cancelled = false;
-    
+
         const fetchUserPosts = async () => {
             setIsSubmitting(true);
             const start = Date.now();
             try {
-                // 1) 초안전: 서버 필터/정렬/expand 없이 한 번만 호출
-                //    (필요하면 perPage를 늘리거나 getFullList로 바꿔도 됨)
                 const res = await pb.collection("post").getList(1, 200);
-    
-                // 2) 클라이언트에서 대상 유저 글만 필터
                 let items = Array.isArray(res?.items) ? res.items : [];
                 items = items.filter((p) => {
                     const ed = p?.editor;
@@ -99,13 +80,9 @@ export default function MyPosts() {
                     if (ex && typeof ex === "object" && ex.id) return ex.id === viewedUserId;
                     return false;
                 });
-    
-                // 3) 최신순 정렬
                 items.sort((a, b) => new Date(b?.created || 0) - new Date(a?.created || 0));
-    
                 if (!cancelled) setUserPosts(items);
             } catch (err) {
-                // 실패해도 네트워크 스팸 없이 한 번만 찍힘
                 console.error("게시물 가져오기 실패:", err?.status, err?.message, err?.data);
                 if (!cancelled) setUserPosts([]);
             } finally {
@@ -114,7 +91,7 @@ export default function MyPosts() {
                 if (!cancelled) setTimeout(() => setIsSubmitting(false), remain);
             }
         };
-    
+
         fetchUserPosts();
         return () => { cancelled = true; };
     }, [viewedUserId]);
@@ -142,7 +119,7 @@ export default function MyPosts() {
                                 첫 글을 작성해 보세요!
                             </p>
                         </div>
-                        {user && (!paramUserId || paramUserId === user.id) && (
+                        {authUser && (!paramUserId || paramUserId === authUser.id) && (
                             <CustomButton
                                 text="작성하러 가기"
                                 size="lg"
@@ -166,15 +143,9 @@ export default function MyPosts() {
                             <PostCardCompact
                                 key={post.id}
                                 post={post}
-
-                                // 두 버전 모두 호환: 권한 판단용
-                                currentUserId={authUser?.id ?? user?.id ?? null}
-                                // (구버전 PostCardSimple도 같이 쓰면)
-                                user={authUser ?? user ?? null}
-
-                                // 헤더 표시용 작성자 (expand 없이도 보장)
+                                currentUserId={authUser?.id ?? null}
+                                user={authUser ?? null}
                                 author={viewedUser}
-
                                 swiper={false}
                                 showInfoHeader={true}
                                 showStatusBadge={true}


### PR DESCRIPTION
# PR 서식

## PR 이름
프로필 편집 플로우 정리 — 탈퇴 기능, 가입 직후 버그 픽스, 주소 표시 UX 개선

- 수정한 이슈: 
   #101
   #102 
   #111 

## 반영 브랜치
```feature/profile-settings```

## PR 유형

- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 주석 추가 및 수정

## PR 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] 문서에 해당 변경 사항을 업데이트 했습니다.
- [x] 해당 변경은 에러를 발생시키지 않았습니다.

### PR 상세(활동 및 수정사항)

- 내 정보 수정 버튼을 <Link>로 전환해 호버 시 상태바에 /mypage/edit 경로가 노출되도록 UX 개선.
- 회원 탈퇴 기능 구현: 소유 레코드 정리 → 계정 삭제 → 세션/로컬 흔적 제거 → 홈으로 이동, 탈퇴 직후 404 방지 가드.
- 가입 직후 ‘작성한 모임’ 진입 오류(undefined user)를 authUser 참조로 교체해 해결.
- 닉네임·프로필 이미지 수정 화면과 저장 플로우 구현(중복확인, 기존 이미지 미리보기, 선택/기본 라디오, 저장 후 마이페이지로).

### 변경 파일
- src/App.jsx
- src/lib/NavItems.js
- src/lib/deleteAccountWithConfirm.js
- src/pages/MyInfoEdit.jsx
- src/pages/MyPage.jsx
- src/pages/MyPosts.jsx