### PR TITLE
feat: 댓글 시스템 도입

### DIFF
--- a/src/components/Badges/TimeBadge.jsx
+++ b/src/components/Badges/TimeBadge.jsx
@@ -1,3 +1,4 @@
+// src/components/Badges/TimeBadge.jsx
 import React from "react";
 import PropTypes from "prop-types";
 
@@ -8,9 +9,9 @@ function formatDateDot(date) {
     return `${y}.${m}.${d}`;
 }
 
-function formatTimeKorean(updated, now = new Date()) {
-    const date = updated instanceof Date ? updated : new Date(updated);
-    if (isNaN(date.getTime())) return ""; // ← 파싱 실패 시 빈 문자열
+function formatTimeKorean(value, now = new Date()) {
+    const date = value instanceof Date ? value : new Date(value);
+    if (isNaN(date.getTime())) return "";
     const diffMs = now.getTime() - date.getTime();
     if (diffMs < 0) return formatDateDot(date);
 
@@ -25,25 +26,63 @@ function formatTimeKorean(updated, now = new Date()) {
 }
 
 export default function TimeBadge({
+    /** ✅ 확장: created + updated 동시 지원 */
+    created,
     updated,
+
+    /** ⬇️ 하위호환: 과거처럼 updated 하나만 쓰는 경우도 동작 */
+    // updated prop 그대로 사용 (위와 동일 이름이라 둘 다 받을 수 있음)
+
     now,
     as = "span",
     titleFormat = true,
-    timeClass
+    timeClass,
 }) {
+    const Comp = as;
+
+    // 1) created가 제공되면: "작성시각 [· 수정됨 ...]" 형태
+    if (created != null) {
+        const createdDisplay = formatTimeKorean(created, now);
+        if (!createdDisplay) return null;
+
+        const createdDateObj = created instanceof Date ? created : new Date(created);
+        const updatedDisplay =
+            updated != null && String(updated) !== String(created)
+                ? formatTimeKorean(updated, now)
+                : null;
+        const updatedDateObj = updated instanceof Date ? updated : new Date(updated);
+
+        return (
+            <Comp
+                className={`whitespace-nowrap text-[var(--color-gray-5)] text-mo-text tablet:text-tab-text desktop:text-pc-text ${timeClass || ""}`}
+                dateTime={as === "time" ? createdDateObj.toISOString() : undefined}
+                title={
+                    titleFormat
+                        ? updatedDisplay
+                            ? `${createdDateObj.toLocaleString()} · 수정됨 ${updatedDateObj.toLocaleString()}`
+                            : createdDateObj.toLocaleString()
+                        : undefined
+                }
+            >
+                {createdDisplay}
+                {updatedDisplay ? <span> · 수정됨 {updatedDisplay}</span> : null}
+            </Comp>
+        );
+    }
+
+    // 2) 하위호환: updated 하나만 주어진 경우 기존 로직
     if (updated == null) return null;
 
-    // “방금”, “N분 전”, “N시간 전”, “YYYY.MM.DD” 같은 완성 텍스트면 그대로 표시
+    // "방금, N분 전, N시간 전, YYYY.MM.DD" 같은 완제품 텍스트면 그대로
     if (typeof updated === "string") {
         const looksFormatted =
             /방금/.test(updated) ||
             /전$/.test(updated) ||
             /^\d{4}\.\d{1,2}\.\d{1,2}$/.test(updated);
         if (looksFormatted) {
-            const Comp = as;
             return (
                 <Comp
-                    className={`text-[var(--color-gray-5)] text-mo-text tablet:text-tab-text desktop:text-pc-text ${timeClass}`}
+                    className={`text-[var(--color-gray-5)] text-mo-text tablet:text-tab-text desktop:text-pc-text ${timeClass || ""}`}
                     title={titleFormat ? updated : undefined}
                 >
                     {updated}
@@ -52,15 +91,13 @@ export default function TimeBadge({
         }
     }
 
-    // 그 외(ISO/Date/숫자) → 규칙대로 포맷
-    const Comp = as;
     const dateObj = updated instanceof Date ? updated : new Date(updated);
     const display = formatTimeKorean(updated, now);
-    if (!display) return null; // 파싱 실패 안전가드
+    if (!display) return null;
 
     return (
         <Comp
-            className={`whitespace-nowrap text-[var(--color-gray-5)] text-mo-text tablet:text-tab-text desktop:text-pc-text ${timeClass}`}
+            className={`whitespace-nowrap text-[var(--color-gray-5)] text-mo-text tablet:text-tab-text desktop:text-pc-text ${timeClass || ""}`}
             dateTime={as === "time" ? dateObj.toISOString() : undefined}
             title={titleFormat ? dateObj.toLocaleString() : undefined}
         >
@@ -70,13 +107,10 @@ export default function TimeBadge({
 }
 
 TimeBadge.propTypes = {
-    updated: PropTypes.oneOfType([
-        PropTypes.string,
-        PropTypes.number,
-        PropTypes.instanceOf(Date),
-    ]),
-    className: PropTypes.string,
+    created: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.instanceOf(Date)]),
+    updated: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.instanceOf(Date)]),
     now: PropTypes.instanceOf(Date),
     as: PropTypes.oneOfType([PropTypes.string, PropTypes.elementType]),
     titleFormat: PropTypes.bool,
+    timeClass: PropTypes.string,
 };

--- a/src/components/Comments/PostCommentForm.jsx
+++ b/src/components/Comments/PostCommentForm.jsx
@@ -1,0 +1,61 @@
+import React from "react";
+import pb from "../../lib/pocketbase";
+import { useAuth } from "../../contexts/AuthContext";
+import Input from "../Input/Input";
+import CustomButton from "../CustomButton/CustomButton";
+
+/**
+ * PostDetail에 포함해서 사용하는 댓글 등록 폼
+ * - postId: 필수 (어떤 게시물에 달 댓글인지)
+ * - onCreated: 성공 시 호출 (목록/카운트 갱신용)
+ */
+export default function PostCommentForm({ postId, onCreated, className = "" }) {
+    const { user } = useAuth();
+    const [comment, setComment] = React.useState("");
+    const [submitting, setSubmitting] = React.useState(false);
+
+    const canSubmit = !!user?.id && !!postId && comment.trim().length > 0 && comment.length <= 300;
+
+    async function handleSubmit(e) {
+        e?.preventDefault?.();
+        if (!canSubmit || submitting) return;
+
+        try {
+            setSubmitting(true);
+
+            await pb.collection("post_comments").create({
+                post: postId,
+                user: user.id,
+                comment: comment.trim(),
+            });
+
+            setComment("");
+            onCreated?.(); // 외부(목록/카운트) 갱신 트리거
+        } catch (err) {
+            console.error("댓글 등록 실패:", err);
+            alert("댓글 등록 중 문제가 발생했습니다. 잠시 후 다시 시도해주세요.");
+        } finally {
+            setSubmitting(false);
+        }
+    }
+
+    return (
+        <form onSubmit={handleSubmit} className={["flex flex-col gap-2", className].join(" ")}>
+            <Input
+                value={comment}
+                onChange={(e) => setComment(e.target.value)}
+                placeholder="최대 300자까지 가능해요."
+                name="요리모임에 대한 소개"
+                textarea
+                disabled={submitting}
+            />
+            <CustomButton
+                text="댓글 작성"
+                size="sm"
+                custombuttonClass="self-end !w-[70px]"
+                type="submit"
+                disabled={!canSubmit || submitting}
+            />
+        </form>
+    );
+}

--- a/src/components/Comments/PostCommentForm.jsx
+++ b/src/components/Comments/PostCommentForm.jsx
@@ -3,6 +3,7 @@ import pb from "../../lib/pocketbase";
 import { useAuth } from "../../contexts/AuthContext";
 import Input from "../Input/Input";
 import CustomButton from "../CustomButton/CustomButton";
+import { useConfirm } from "../Modal/ConfirmProvider";
 
 /**
  * PostDetail에 포함해서 사용하는 댓글 등록 폼
@@ -13,6 +14,7 @@ export default function PostCommentForm({ postId, onCreated, className = "" }) {
     const { user } = useAuth();
     const [comment, setComment] = React.useState("");
     const [submitting, setSubmitting] = React.useState(false);
+    const confirm = useConfirm();
 
     const canSubmit = !!user?.id && !!postId && comment.trim().length > 0 && comment.length <= 300;
 
@@ -30,10 +32,15 @@ export default function PostCommentForm({ postId, onCreated, className = "" }) {
             });
 
             setComment("");
+
+            window.dispatchEvent(new CustomEvent("comments:changed", { detail: { postId } }));
+
             onCreated?.(); // 외부(목록/카운트) 갱신 트리거
         } catch (err) {
             console.error("댓글 등록 실패:", err);
-            alert("댓글 등록 중 문제가 발생했습니다. 잠시 후 다시 시도해주세요.");
+            confirm({
+                title: "댓글 등록 중 문제가 발생했습니다. 잠시 후 다시 시도해주세요.",
+            });
         } finally {
             setSubmitting(false);
         }

--- a/src/components/Comments/PostCommentList.jsx
+++ b/src/components/Comments/PostCommentList.jsx
@@ -1,3 +1,4 @@
+// src/components/Comments/PostCommentList.jsx
 import React from "react";
 import pb from "../../lib/pocketbase";
 import InfoHeaderRowGroup from "../Info/InfoHeaderRowGroup";
@@ -6,7 +7,7 @@ function formatRelative(iso) {
     if (!iso) return "";
     const t = new Date(iso).getTime();
     const now = Date.now();
-    const diff = Math.max(0, Math.floor((now - t) / 1000)); // sec
+    const diff = Math.max(0, Math.floor((now - t) / 1000));
     if (diff < 60) return "방금 전";
     const m = Math.floor(diff / 60);
     if (m < 60) return `${m}분 전`;
@@ -18,14 +19,15 @@ function formatRelative(iso) {
 
 /**
  * 특정 postId에 달린 댓글 목록을 최신순으로 보여줍니다.
- * - 지금 단계: 시간 노출 + 수정/삭제 UI만 우선 추가
- * - 다음 단계: 실제 수정/삭제 동작 연결
+ * - 수정/삭제 PB 연동 완료
  */
 export default function PostCommentList({ postId, currentUser }) {
     const [items, setItems] = React.useState([]);
     const [loading, setLoading] = React.useState(true);
     const [editingId, setEditingId] = React.useState(null);
     const [draft, setDraft] = React.useState("");
+    const [saving, setSaving] = React.useState(false);
+    const [deletingId, setDeletingId] = React.useState(null);
 
     const fetchList = React.useCallback(async () => {
         if (!postId) return;
@@ -67,18 +69,51 @@ export default function PostCommentList({ postId, currentUser }) {
     function cancelEdit() {
         setEditingId(null);
         setDraft("");
+        setSaving(false);
     }
+
     async function saveEdit() {
-        // ★ 다음 단계에서 pb.collection("post_comments").update(editingId, { comment: draft }) 연결
-        // 지금은 UI만: 저장 눌러도 편집 종료만 수행
-        setEditingId(null);
-        setDraft("");
-        // fetchList();  // 실제 연결 시 유지
+        if (!editingId) return;
+        const content = draft.trim();
+        if (content.length === 0) {
+            alert("내용을 입력하세요.");
+            return;
+        }
+        if (content.length > 300) {
+            alert("최대 300자까지 가능합니다.");
+            return;
+        }
+
+        try {
+            setSaving(true);
+            // 권한: user == @request.auth.id 이므로 서버에서 403이면 막힘
+            await pb.collection("post_comments").update(editingId, { comment: content });
+            // 낙관적 종료(실시간 구독으로 목록 갱신됨)
+            setEditingId(null);
+            setDraft("");
+        } catch (err) {
+            console.error("댓글 수정 실패:", err);
+            alert("수정 중 문제가 발생했습니다. 잠시 후 다시 시도해주세요.");
+        } finally {
+            setSaving(false);
+        }
     }
+
     async function handleDelete(item) {
-        // ★ 다음 단계에서 실제 삭제 연결
-        // confirm 모달 후 delete 진행 예정
-        console.log("TODO: delete", item.id);
+        if (!item?.id) return;
+        if (!confirm("이 댓글을 삭제할까요?")) return;
+
+        try {
+            setDeletingId(item.id);
+            await pb.collection("post_comments").delete(item.id);
+            // 실시간 구독으로 자동 갱신. 즉시 반영 원하면 아래 주석 해제.
+            // await fetchList();
+        } catch (err) {
+            console.error("댓글 삭제 실패:", err);
+            alert("삭제 중 문제가 발생했습니다. 잠시 후 다시 시도해주세요.");
+        } finally {
+            setDeletingId(null);
+        }
     }
 
     if (!postId) return null;
@@ -105,18 +140,19 @@ export default function PostCommentList({ postId, currentUser }) {
                 const author = it?.expand?.user ?? null;
                 const isMine = currentUser?.id && it?.user === currentUser.id;
                 const isEditing = editingId === it.id;
+                const isDeleting = deletingId === it.id;
 
                 return (
                     <li key={it.id} className="flex flex-col gap-2">
-                        {/* 헤더 영역: 작성자 / 우측 액션 */}
+                        {/* 헤더 */}
                         <div className="flex items-start justify-between">
                             <div className="min-w-0">
                                 <InfoHeaderRowGroup
                                     post={null}
                                     currentUserId={currentUser?.id}
                                     author={author}
-                                    createdAt={it?.created}     // 작성시각
-                                    updatedAt={it?.updated}     // 수정시각
+                                    createdAt={it?.created}
+                                    updatedAt={it?.updated}
                                     showSvgIcon={false}
                                     showStatusBadge={false}
                                     showEditAndDelete={false}
@@ -124,22 +160,24 @@ export default function PostCommentList({ postId, currentUser }) {
                             </div>
 
                             {isMine ? (
-                                <div className="flex shrink-0 items-center gap-3 text-[var(--color-gray-6)] text-mo-text tablet:text-tab-text desktop:text-pc-text">
+                                <div className="flex shrink-0 items-center gap-2 text-[var(--color-gray-6)] text-mo-text tablet:text-tab-text desktop:text-pc-text">
                                     {!isEditing ? (
                                         <>
                                             <button
                                                 type="button"
-                                                className="hover:opacity-80"
+                                                className="hover:opacity-80 disabled:opacity-50"
                                                 onClick={() => beginEdit(it)}
+                                                disabled={isDeleting}
                                             >
                                                 수정
                                             </button>
                                             <button
                                                 type="button"
-                                                className="hover:opacity-80"
+                                                className="hover:opacity-80 disabled:opacity-50"
                                                 onClick={() => handleDelete(it)}
+                                                disabled={isDeleting}
                                             >
-                                                삭제
+                                                {isDeleting ? "삭제중…" : "삭제"}
                                             </button>
                                         </>
                                     ) : null}
@@ -160,19 +198,22 @@ export default function PostCommentList({ postId, currentUser }) {
                                     value={draft}
                                     onChange={(e) => setDraft(e.target.value)}
                                     placeholder="최대 300자까지 가능해요."
+                                    disabled={saving}
                                 />
                                 <div className="flex items-center gap-2 self-end">
                                     <button
                                         type="button"
-                                        className="px-3 py-1 rounded-[8px] bg-[var(--color-primary)] text-[var(--color-gray-0)] hover:opacity-90"
+                                        className="px-3 py-1 rounded-[8px] bg-[var(--color-primary)] text-[var(--color-gray-0)] hover:opacity-90 disabled:opacity-50"
                                         onClick={saveEdit}
+                                        disabled={saving}
                                     >
-                                        저장
+                                        {saving ? "저장중…" : "저장"}
                                     </button>
                                     <button
                                         type="button"
-                                        className="px-3 py-1 rounded-[8px] bg-[var(--color-gray-2)] text-[var(--color-gray-7)] hover:opacity-90"
+                                        className="px-3 py-1 rounded-[8px] bg-[var(--color-gray-2)] text-[var(--color-gray-7)] hover:opacity-90 disabled:opacity-50"
                                         onClick={cancelEdit}
+                                        disabled={saving}
                                     >
                                         취소
                                     </button>

--- a/src/components/Comments/PostCommentList.jsx
+++ b/src/components/Comments/PostCommentList.jsx
@@ -1,0 +1,187 @@
+import React from "react";
+import pb from "../../lib/pocketbase";
+import InfoHeaderRowGroup from "../Info/InfoHeaderRowGroup";
+
+function formatRelative(iso) {
+    if (!iso) return "";
+    const t = new Date(iso).getTime();
+    const now = Date.now();
+    const diff = Math.max(0, Math.floor((now - t) / 1000)); // sec
+    if (diff < 60) return "방금 전";
+    const m = Math.floor(diff / 60);
+    if (m < 60) return `${m}분 전`;
+    const h = Math.floor(m / 60);
+    if (h < 24) return `${h}시간 전`;
+    const d = Math.floor(h / 24);
+    return `${d}일 전`;
+}
+
+/**
+ * 특정 postId에 달린 댓글 목록을 최신순으로 보여줍니다.
+ * - 지금 단계: 시간 노출 + 수정/삭제 UI만 우선 추가
+ * - 다음 단계: 실제 수정/삭제 동작 연결
+ */
+export default function PostCommentList({ postId, currentUser }) {
+    const [items, setItems] = React.useState([]);
+    const [loading, setLoading] = React.useState(true);
+    const [editingId, setEditingId] = React.useState(null);
+    const [draft, setDraft] = React.useState("");
+
+    const fetchList = React.useCallback(async () => {
+        if (!postId) return;
+        setLoading(true);
+        try {
+            const res = await pb.collection("post_comments").getList(1, 50, {
+                filter: `post = "${postId}"`,
+                sort: "-created",
+                expand: "user",
+            });
+            setItems(Array.isArray(res?.items) ? res.items : []);
+        } catch (err) {
+            console.error("댓글 목록 불러오기 실패:", err);
+        } finally {
+            setLoading(false);
+        }
+    }, [postId]);
+
+    React.useEffect(() => {
+        let unsub = null;
+        fetchList();
+        (async () => {
+            try {
+                unsub = await pb.collection("post_comments").subscribe("*", (e) => {
+                    const p = e?.record?.post;
+                    if (p === postId) fetchList();
+                });
+            } catch (_) {}
+        })();
+        return () => {
+            try { unsub && pb.collection("post_comments").unsubscribe("*"); } catch (_) {}
+        };
+    }, [postId, fetchList]);
+
+    function beginEdit(item) {
+        setEditingId(item.id);
+        setDraft(item.comment || "");
+    }
+    function cancelEdit() {
+        setEditingId(null);
+        setDraft("");
+    }
+    async function saveEdit() {
+        // ★ 다음 단계에서 pb.collection("post_comments").update(editingId, { comment: draft }) 연결
+        // 지금은 UI만: 저장 눌러도 편집 종료만 수행
+        setEditingId(null);
+        setDraft("");
+        // fetchList();  // 실제 연결 시 유지
+    }
+    async function handleDelete(item) {
+        // ★ 다음 단계에서 실제 삭제 연결
+        // confirm 모달 후 delete 진행 예정
+        console.log("TODO: delete", item.id);
+    }
+
+    if (!postId) return null;
+
+    if (loading) {
+        return (
+            <ul className="flex flex-col gap-3">
+                <li className="text-[var(--color-gray-5)]">불러오는 중…</li>
+            </ul>
+        );
+    }
+
+    if (items.length === 0) {
+        return (
+            <ul className="flex flex-col gap-3">
+                <li className="text-[var(--color-gray-5)]">첫 댓글을 남겨보세요!</li>
+            </ul>
+        );
+    }
+
+    return (
+        <ul className="flex flex-col gap-3">
+            {items.map((it) => {
+                const author = it?.expand?.user ?? null;
+                const isMine = currentUser?.id && it?.user === currentUser.id;
+                const isEditing = editingId === it.id;
+
+                return (
+                    <li key={it.id} className="flex flex-col gap-2">
+                        {/* 헤더 영역: 작성자 / 우측 액션 */}
+                        <div className="flex items-start justify-between">
+                            <div className="min-w-0">
+                                <InfoHeaderRowGroup
+                                    post={null}
+                                    currentUserId={currentUser?.id}
+                                    author={author}
+                                    showSvgIcon={false}
+                                    showStatusBadge={false}
+                                    showEditAndDelete={false}
+                                />
+                            </div>
+
+                            {isMine ? (
+                                <div className="flex shrink-0 items-center gap-3 text-[var(--color-gray-6)] text-mo-text tablet:text-tab-text desktop:text-pc-text">
+                                    {!isEditing ? (
+                                        <>
+                                            <button
+                                                type="button"
+                                                className="hover:opacity-80"
+                                                onClick={() => beginEdit(it)}
+                                            >
+                                                수정
+                                            </button>
+                                            <button
+                                                type="button"
+                                                className="hover:opacity-80"
+                                                onClick={() => handleDelete(it)}
+                                            >
+                                                삭제
+                                            </button>
+                                        </>
+                                    ) : null}
+                                </div>
+                            ) : null}
+                        </div>
+
+                        {/* 본문 / 편집 UI */}
+                        {!isEditing ? (
+                            <p className="text-[var(--color-gray-7)] text-mo-text tablet:text-tab-text desktop:text-pc-text break-words">
+                                {it.comment}
+                            </p>
+                        ) : (
+                            <div className="flex flex-col gap-2">
+                                <textarea
+                                    className="w-full rounded-[10px] bg-[var(--color-gray-1)] px-4 py-3 outline-none text-[var(--color-gray-7)] text-mo-text tablet:text-tab-text desktop:text-pc-text"
+                                    maxLength={300}
+                                    value={draft}
+                                    onChange={(e) => setDraft(e.target.value)}
+                                    placeholder="최대 300자까지 가능해요."
+                                />
+                                <div className="flex items-center gap-2 self-end">
+                                    <button
+                                        type="button"
+                                        className="px-3 py-1 rounded-[8px] bg-[var(--color-primary)] text-[var(--color-gray-0)] hover:opacity-90"
+                                        onClick={saveEdit}
+                                    >
+                                        저장
+                                    </button>
+                                    <button
+                                        type="button"
+                                        className="px-3 py-1 rounded-[8px] bg-[var(--color-gray-2)] text-[var(--color-gray-7)] hover:opacity-90"
+                                        onClick={cancelEdit}
+                                    >
+                                        취소
+                                    </button>
+                                </div>
+                            </div>
+                        )}
+
+                        <span className="h-[1px] w-full bg-[var(--color-gray-2)]" />
+                    </li>
+                );
+            })}
+        </ul>
+    );
+}

--- a/src/components/Comments/PostCommentList.jsx
+++ b/src/components/Comments/PostCommentList.jsx
@@ -2,6 +2,8 @@
 import React from "react";
 import pb from "../../lib/pocketbase";
 import InfoHeaderRowGroup from "../Info/InfoHeaderRowGroup";
+import Input from "../Input/Input";
+import CustomButton from '../CustomButton/CustomButton';
 
 function formatRelative(iso) {
     if (!iso) return "";
@@ -136,7 +138,7 @@ export default function PostCommentList({ postId, currentUser }) {
 
     return (
         <ul className="flex flex-col gap-3">
-            {items.map((it) => {
+            {items.map((it, index) => {
                 const author = it?.expand?.user ?? null;
                 const isMine = currentUser?.id && it?.user === currentUser.id;
                 const isEditing = editingId === it.id;
@@ -160,7 +162,7 @@ export default function PostCommentList({ postId, currentUser }) {
                             </div>
 
                             {isMine ? (
-                                <div className="flex shrink-0 items-center gap-2 text-[var(--color-gray-6)] text-mo-text tablet:text-tab-text desktop:text-pc-text">
+                                <div className="flex shrink-0 items-center gap-2 text-[var(--color-gray-6)] text-mo-text tablet:text-tab-text desktop:text-pc-text ">
                                     {!isEditing ? (
                                         <>
                                             <button
@@ -171,6 +173,12 @@ export default function PostCommentList({ postId, currentUser }) {
                                             >
                                                 수정
                                             </button>
+                                            <CustomButton 
+                                                variant="tertiary"
+                                                text="수정"
+                                                basebuttonClass="!hover:pointer-events-none"
+                                                basebuttontextClass="!text-[var(--color-gray-6)]"
+                                            />
                                             <button
                                                 type="button"
                                                 className="hover:opacity-80 disabled:opacity-50"
@@ -192,18 +200,19 @@ export default function PostCommentList({ postId, currentUser }) {
                             </p>
                         ) : (
                             <div className="flex flex-col gap-2">
-                                <textarea
-                                    className="w-full rounded-[10px] bg-[var(--color-gray-1)] px-4 py-3 outline-none text-[var(--color-gray-7)] text-mo-text tablet:text-tab-text desktop:text-pc-text"
-                                    maxLength={300}
+                                <Input
                                     value={draft}
                                     onChange={(e) => setDraft(e.target.value)}
                                     placeholder="최대 300자까지 가능해요."
+                                    name="요리모임에 대한 소개"
+                                    textarea
                                     disabled={saving}
+
                                 />
-                                <div className="flex items-center gap-2 self-end">
+                                <div className="flex shrink-0 items-center justify-end gap-2 text-[var(--color-gray-6)] text-mo-text tablet:text-tab-text desktop:text-pc-text">
                                     <button
                                         type="button"
-                                        className="px-3 py-1 rounded-[8px] bg-[var(--color-primary)] text-[var(--color-gray-0)] hover:opacity-90 disabled:opacity-50"
+                                        className="hover:opacity-80 disabled:opacity-50"
                                         onClick={saveEdit}
                                         disabled={saving}
                                     >
@@ -211,7 +220,7 @@ export default function PostCommentList({ postId, currentUser }) {
                                     </button>
                                     <button
                                         type="button"
-                                        className="px-3 py-1 rounded-[8px] bg-[var(--color-gray-2)] text-[var(--color-gray-7)] hover:opacity-90 disabled:opacity-50"
+                                        className="hover:opacity-80 disabled:opacity-50"
                                         onClick={cancelEdit}
                                         disabled={saving}
                                     >
@@ -221,7 +230,9 @@ export default function PostCommentList({ postId, currentUser }) {
                             </div>
                         )}
 
-                        <span className="h-[1px] w-full bg-[var(--color-gray-2)]" />
+                        {items.length > 1 && index < items.length - 1 && (
+                            <span className="h-[1px] w-full bg-[var(--color-gray-2)]" />
+                        )}
                     </li>
                 );
             })}

--- a/src/components/Comments/PostCommentList.jsx
+++ b/src/components/Comments/PostCommentList.jsx
@@ -115,6 +115,8 @@ export default function PostCommentList({ postId, currentUser }) {
                                     post={null}
                                     currentUserId={currentUser?.id}
                                     author={author}
+                                    createdAt={it?.created}     // 작성시각
+                                    updatedAt={it?.updated}     // 수정시각
                                     showSvgIcon={false}
                                     showStatusBadge={false}
                                     showEditAndDelete={false}

--- a/src/components/Comments/PostCommentList.jsx
+++ b/src/components/Comments/PostCommentList.jsx
@@ -3,21 +3,8 @@ import React from "react";
 import pb from "../../lib/pocketbase";
 import InfoHeaderRowGroup from "../Info/InfoHeaderRowGroup";
 import Input from "../Input/Input";
-import CustomButton from '../CustomButton/CustomButton';
-
-function formatRelative(iso) {
-    if (!iso) return "";
-    const t = new Date(iso).getTime();
-    const now = Date.now();
-    const diff = Math.max(0, Math.floor((now - t) / 1000));
-    if (diff < 60) return "방금 전";
-    const m = Math.floor(diff / 60);
-    if (m < 60) return `${m}분 전`;
-    const h = Math.floor(m / 60);
-    if (h < 24) return `${h}시간 전`;
-    const d = Math.floor(h / 24);
-    return `${d}일 전`;
-}
+import CustomButton from "../CustomButton/CustomButton";
+import { useConfirm } from "../Modal/ConfirmProvider";
 
 /**
  * 특정 postId에 달린 댓글 목록을 최신순으로 보여줍니다.
@@ -30,6 +17,7 @@ export default function PostCommentList({ postId, currentUser }) {
     const [draft, setDraft] = React.useState("");
     const [saving, setSaving] = React.useState(false);
     const [deletingId, setDeletingId] = React.useState(null);
+    const confirm = useConfirm();
 
     const fetchList = React.useCallback(async () => {
         if (!postId) return;
@@ -78,11 +66,15 @@ export default function PostCommentList({ postId, currentUser }) {
         if (!editingId) return;
         const content = draft.trim();
         if (content.length === 0) {
-            alert("내용을 입력하세요.");
+            confirm({
+                title: "내용을 입력하세요.",
+            });
             return;
         }
         if (content.length > 300) {
-            alert("최대 300자까지 가능합니다.");
+            confirm({
+                title: "최대 300자까지 가능합니다.",
+            });
             return;
         }
 
@@ -103,16 +95,24 @@ export default function PostCommentList({ postId, currentUser }) {
 
     async function handleDelete(item) {
         if (!item?.id) return;
-        if (!confirm("이 댓글을 삭제할까요?")) return;
+
+        const ok = await confirm({
+            title: "댓글을 삭제하시겠어요?",
+            confirmText: "삭제",
+            cancelText: "취소",
+        });
+        if (!ok) return;
 
         try {
             setDeletingId(item.id);
             await pb.collection("post_comments").delete(item.id);
-            // 실시간 구독으로 자동 갱신. 즉시 반영 원하면 아래 주석 해제.
-            // await fetchList();
+            await fetchList();
+            window.dispatchEvent(new CustomEvent("comments:changed", { detail: { postId } }));
         } catch (err) {
             console.error("댓글 삭제 실패:", err);
-            alert("삭제 중 문제가 발생했습니다. 잠시 후 다시 시도해주세요.");
+            confirm({
+                title: "삭제 중 문제가 발생했습니다. 잠시 후 다시 시도해주세요.",
+            });
         } finally {
             setDeletingId(null);
         }
@@ -162,31 +162,23 @@ export default function PostCommentList({ postId, currentUser }) {
                             </div>
 
                             {isMine ? (
-                                <div className="flex shrink-0 items-center gap-2 text-[var(--color-gray-6)] text-mo-text tablet:text-tab-text desktop:text-pc-text ">
+                                <div className="flex shrink-0 items-center gap-3 text-mo-text tablet:text-tab-text desktop:text-pc-text">
                                     {!isEditing ? (
                                         <>
-                                            <button
-                                                type="button"
-                                                className="hover:opacity-80 disabled:opacity-50"
-                                                onClick={() => beginEdit(it)}
-                                                disabled={isDeleting}
-                                            >
-                                                수정
-                                            </button>
                                             <CustomButton 
                                                 variant="tertiary"
                                                 text="수정"
-                                                basebuttonClass="!hover:pointer-events-none"
-                                                basebuttontextClass="!text-[var(--color-gray-6)]"
+                                                onClick={() => beginEdit(it)}
+                                                basebuttonClass="group hover:!bg-transparent !p-0"
+                                                basebuttontextClass="!text-[var(--color-gray-6)] group-hover:!text-[var(--color-gray-4)]"
                                             />
-                                            <button
-                                                type="button"
-                                                className="hover:opacity-80 disabled:opacity-50"
+                                            <CustomButton 
+                                                variant="tertiary"
+                                                text={isDeleting ? "삭제중…" : "삭제"}
                                                 onClick={() => handleDelete(it)}
-                                                disabled={isDeleting}
-                                            >
-                                                {isDeleting ? "삭제중…" : "삭제"}
-                                            </button>
+                                                basebuttonClass="group hover:!bg-transparent !p-0"
+                                                basebuttontextClass="!text-[var(--color-gray-6)] group-hover:!text-[var(--color-gray-4)]"
+                                            />
                                         </>
                                     ) : null}
                                 </div>
@@ -207,25 +199,24 @@ export default function PostCommentList({ postId, currentUser }) {
                                     name="요리모임에 대한 소개"
                                     textarea
                                     disabled={saving}
-
                                 />
-                                <div className="flex shrink-0 items-center justify-end gap-2 text-[var(--color-gray-6)] text-mo-text tablet:text-tab-text desktop:text-pc-text">
-                                    <button
-                                        type="button"
-                                        className="hover:opacity-80 disabled:opacity-50"
+                                <div className="flex shrink-0 items-center justify-end gap-3 text-[var(--color-gray-6)] text-mo-text tablet:text-tab-text desktop:text-pc-text">
+                                    <CustomButton 
+                                        variant="tertiary"
+                                        text={saving ? "저장중…" : "저장"}
                                         onClick={saveEdit}
-                                        disabled={saving}
-                                    >
-                                        {saving ? "저장중…" : "저장"}
-                                    </button>
-                                    <button
-                                        type="button"
-                                        className="hover:opacity-80 disabled:opacity-50"
+                                        custombuttonClass="!w-fit"
+                                        basebuttonClass="group hover:!bg-transparent !p-0"
+                                        basebuttontextClass="!text-[var(--color-gray-6)] group-hover:!text-[var(--color-gray-4)]"
+                                    />
+                                    <CustomButton 
+                                        variant="tertiary"
+                                        text="취소"
                                         onClick={cancelEdit}
-                                        disabled={saving}
-                                    >
-                                        취소
-                                    </button>
+                                        custombuttonClass="!w-fit"
+                                        basebuttonClass="group hover:!bg-transparent !p-0"
+                                        basebuttontextClass="!text-[var(--color-gray-6)] group-hover:!text-[var(--color-gray-4)]"
+                                    />
                                 </div>
                             </div>
                         )}

--- a/src/components/Info/InfoComment.jsx
+++ b/src/components/Info/InfoComment.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import pb from "../../lib/pocketbase";
 
 export default function InfoComment({
     count = 0,
@@ -6,15 +7,68 @@ export default function InfoComment({
     infoCommentColor,
     infoCommentSize,
     variant = "v1", // "v1" | "v2"
+    postId, // ★ 추가: post_comments에서 합계를 가져오기 위한 postId
 }) {
+    const [liveCount, setLiveCount] = React.useState(count);
     const baseClass = ["flex items-center gap-[3px]", className].join(" ");
     const textClass = `${infoCommentColor} ${infoCommentSize}`;
+
+    // ★ postId가 주어지면 post_comments를 통해 합계를 조회하고, 실시간으로 반영
+    React.useEffect(() => {
+        let mounted = true;
+        let unsub = null;
+
+        async function fetchCount(pid) {
+            try {
+                // 1개 페이지만 받아도 totalItems로 전체 개수를 얻을 수 있음
+                const res = await pb
+                    .collection("post_comments")
+                    .getList(1, 1, { filter: `post = "${pid}"` });
+                if (!mounted) return;
+                setLiveCount(Number(res?.totalItems || 0));
+            } catch (_) {
+                if (!mounted) return;
+                setLiveCount(count);
+            }
+        }
+
+        async function subscribeRealtime(pid) {
+            try {
+                unsub = await pb
+                    .collection("post_comments")
+                    .subscribe("*", (e) => {
+                        // 해당 post에 대한 변경만 반영
+                        const p = e?.record?.post;
+                        if (!p) return;
+                        // record.post가 단일 relation이면 문자열 id
+                        if (p === pid) {
+                            // 변경마다 다시 total을 가져오는 방식(안전)
+                            fetchCount(pid);
+                        }
+                    });
+            } catch (_) {}
+        }
+
+        if (postId) {
+            fetchCount(postId);
+            subscribeRealtime(postId);
+        } else {
+            setLiveCount(count);
+        }
+
+        return () => {
+            mounted = false;
+            try { unsub && pb.collection("post_comments").unsubscribe("*"); } catch (_) {}
+        };
+    }, [postId, count]);
+
+    const displayCount = postId ? liveCount : count;
 
     if (variant === "v2") {
         // 예: "12개의 댓글"
         return (
             <div className={baseClass}>
-                <span className={textClass}>{count}</span>
+                <span className={textClass}>{displayCount}</span>
                 <span className={textClass}>개의</span>
                 <span className={`${textClass} whitespace-nowrap`}>댓글</span>
             </div>
@@ -25,7 +79,7 @@ export default function InfoComment({
     return (
         <div className={baseClass}>
             <span className={`${textClass} whitespace-nowrap`}>댓글</span>
-            <span className={textClass}>{count}</span>
+            <span className={textClass}>{displayCount}</span>
         </div>
     );
 }

--- a/src/components/Info/InfoComment.jsx
+++ b/src/components/Info/InfoComment.jsx
@@ -1,3 +1,4 @@
+// src/components/Info/InfoComment.jsx
 import React from "react";
 import pb from "../../lib/pocketbase";
 
@@ -6,66 +7,64 @@ export default function InfoComment({
     className = "",
     infoCommentColor,
     infoCommentSize,
-    variant = "v1", // "v1" | "v2"
-    postId, // ★ 추가: post_comments에서 합계를 가져오기 위한 postId
+    variant = "v1",
+    postId,
 }) {
     const [liveCount, setLiveCount] = React.useState(count);
     const baseClass = ["flex items-center gap-[3px]", className].join(" ");
     const textClass = `${infoCommentColor} ${infoCommentSize}`;
 
-    // ★ postId가 주어지면 post_comments를 통해 합계를 조회하고, 실시간으로 반영
-    React.useEffect(() => {
-        let mounted = true;
-        let unsub = null;
-
-        async function fetchCount(pid) {
-            try {
-                // 1개 페이지만 받아도 totalItems로 전체 개수를 얻을 수 있음
-                const res = await pb
-                    .collection("post_comments")
-                    .getList(1, 1, { filter: `post = "${pid}"` });
-                if (!mounted) return;
-                setLiveCount(Number(res?.totalItems || 0));
-            } catch (_) {
-                if (!mounted) return;
-                setLiveCount(count);
-            }
-        }
-
-        async function subscribeRealtime(pid) {
-            try {
-                unsub = await pb
-                    .collection("post_comments")
-                    .subscribe("*", (e) => {
-                        // 해당 post에 대한 변경만 반영
-                        const p = e?.record?.post;
-                        if (!p) return;
-                        // record.post가 단일 relation이면 문자열 id
-                        if (p === pid) {
-                            // 변경마다 다시 total을 가져오는 방식(안전)
-                            fetchCount(pid);
-                        }
-                    });
-            } catch (_) {}
-        }
-
-        if (postId) {
-            fetchCount(postId);
-            subscribeRealtime(postId);
-        } else {
+    async function fetchCount(pid) {
+        try {
+            const res = await pb
+                .collection("post_comments")
+                .getList(1, 1, { filter: `post = "${pid}"` });
+            setLiveCount(Number(res?.totalItems || 0));
+        } catch {
             setLiveCount(count);
         }
+    }
+
+    React.useEffect(() => {
+        if (!postId) {
+            setLiveCount(count);
+            return;
+        }
+
+        let unsub = null;
+
+        // 1) PB 실시간: delete는 관계정보가 없을 수 있으므로 무조건 갱신
+        (async () => {
+            try {
+                unsub = await pb.collection("post_comments").subscribe("*", (e) => {
+                    if (e?.action === "delete") {
+                        fetchCount(postId);
+                        return;
+                    }
+                    const p = e?.record?.post;
+                    if (p === postId) fetchCount(postId);
+                });
+            } catch (_) {}
+        })();
+
+        // 2) 로컬 이벤트: 목록 컴포넌트에서 수동 브로드캐스트 받을 때
+        const onLocal = (ev) => {
+            if (ev?.detail?.postId === postId) fetchCount(postId);
+        };
+        window.addEventListener("comments:changed", onLocal);
+
+        // 초기 1회
+        fetchCount(postId);
 
         return () => {
-            mounted = false;
             try { unsub && pb.collection("post_comments").unsubscribe("*"); } catch (_) {}
+            window.removeEventListener("comments:changed", onLocal);
         };
     }, [postId, count]);
 
     const displayCount = postId ? liveCount : count;
 
     if (variant === "v2") {
-        // 예: "12개의 댓글"
         return (
             <div className={baseClass}>
                 <span className={textClass}>{displayCount}</span>
@@ -75,7 +74,6 @@ export default function InfoComment({
         );
     }
 
-    // v1 (기본): "댓글 12"
     return (
         <div className={baseClass}>
             <span className={`${textClass} whitespace-nowrap`}>댓글</span>
@@ -84,10 +82,5 @@ export default function InfoComment({
     );
 }
 
-// 편의용 별칭
-export function InfoCommentV1(props) {
-    return <InfoComment {...props} variant="v1" />;
-}
-export function InfoCommentV2(props) {
-    return <InfoComment {...props} variant="v2" />;
-}
+export function InfoCommentV1(props) { return <InfoComment {...props} variant="v1" />; }
+export function InfoCommentV2(props) { return <InfoComment {...props} variant="v2" />; }

--- a/src/components/Info/InfoHeader.jsx
+++ b/src/components/Info/InfoHeader.jsx
@@ -10,28 +10,27 @@ export default function InfoHeader({
     name,
 
     // 하위 호환/선택
-    author,                 // 작성자 레코드 (우선)
-    user,                   // 기존 user 레코드
-    currentUserId,          // 권한/링크 판단용 (내 계정 id)
-    createdAt,              // 시간 뱃지에 표시할 값 (ISO | Date)
+    author,
+    user,
+    currentUserId,
+    createdAt,          // 작성 시간
+    updatedAt,          // 추가: 수정 시간 (선택)
 
     // 스타일/표시 옵션
     className = "",
     nameSize = "md",
-    avatarSize = "md",      // 'md' | 'lg'
+    avatarSize = "md",
     nameClass,
     timeClass,
 
-    // 링크 동작 제어 (ProfileAvatar로 전달)
-    linkBehavior = "auto",  // 'auto' | 'self' | 'none'
-    path,                   // ProfileAvatar path override (선택)
+    // 링크 동작 제어
+    linkBehavior = "auto",
+    path,
 
-    onRequireLogin,         // 로그아웃 시 호출할 가드
+    onRequireLogin,
 }) {
-    // 1) 표시에 사용할 레코드: author > user > null
     const recordUser = author ?? user ?? null;
 
-    // 2) 표시 이름: name > recordUser 필드 > 기본값
     const displayName = useMemo(() => {
         if (typeof name === "string" && name.length > 0) return name;
         return (
@@ -42,18 +41,13 @@ export default function InfoHeader({
         );
     }, [name, recordUser]);
 
-    // 3) 아바타 사이즈 클래스를 ProfileAvatar 규격에 맞춤
     const avatarSizeClass = useMemo(() => {
-        const map = {
-            md: "w-[40px] h-[40px]",
-            lg: "w-[132px] h-[132px]",
-        };
+        const map = { md: "w-[40px] h-[40px]", lg: "w-[132px] h-[132px]" };
         return map[avatarSize] || map.md;
     }, [avatarSize]);
 
     return (
         <div className={["flex items-center gap-2", className].join(" ")}>
-            {/* A. 유저 레코드가 있으면: ProfileAvatar(자동 링크/마이페이지 처리) */}
             {recordUser ? (
                 <ProfileAvatar
                     user={recordUser}
@@ -64,7 +58,6 @@ export default function InfoHeader({
                     onRequireLogin={onRequireLogin}
                 />
             ) : (
-                /* B. 레코드는 없지만 avatarUrl이 있으면: 정적 이미지 */
                 avatarUrl ? (
                     <img
                         src={avatarUrl}
@@ -77,7 +70,6 @@ export default function InfoHeader({
                         loading="lazy"
                     />
                 ) : (
-                    /* C. 둘 다 없으면: ProfileAvatar 기본 아이콘으로 폴백 */
                     <ProfileAvatar
                         user={null}
                         currentUserId={currentUserId}
@@ -89,22 +81,19 @@ export default function InfoHeader({
             )}
 
             <div className="flex flex-col">
-                {/* name 프롭이 오면 그대로 텍스트, 아니면 UserName 컴포넌트 사용 */}
                 {typeof name === "string" && name.length > 0 ? (
                     <span className={["font-bold", nameClass].join(" ")}>
                         {displayName}
                     </span>
                 ) : (
-                    <UserName
-                        user={recordUser}
-                        size={nameSize}
-                        nameClass={nameClass}
-                    />
+                    <UserName user={recordUser} size={nameSize} nameClass={nameClass} />
                 )}
 
+                {/* TimeBadge에 created/updated 동시 전달 */}
                 <TimeBadge
-                    updated={createdAt}
                     as="time"
+                    created={createdAt}
+                    updated={updatedAt}
                     timeClass={timeClass}
                 />
             </div>

--- a/src/components/Info/InfoHeaderRowGroup.jsx
+++ b/src/components/Info/InfoHeaderRowGroup.jsx
@@ -1,22 +1,14 @@
+// src/components/Info/InfoHeaderRowGroup.jsx
 import React, { useMemo, useState } from "react";
 import InfoHeader from "./InfoHeader";
 import StatusBadgeIconGroup from "../Badges/StatusBadgeIconGroup";
 import { iconNameOf } from "../../lib/postOwner";
 
-/**
- * 좌측: InfoHeader(아바타/이름/업데이트시간)
- * 우측: StatusBadgeIconGroup(상태배지 + 아이콘)
- *
- * ⚠️ 작성자 표시와 권한 판단을 분리:
- * - author: 작성자 객체(보통 post.expand.editor)
- * - currentUserId: 현재 로그인한 유저 id (권한/아이콘 판단용)
- *
- * 💡 아바타 파일 URL은 프로젝트 util을 넘겨서(fileUrl) 계산하도록 했습니다.
- */
 export default function InfoHeaderRowGroup({
     // InfoHeader 영역
-    author,                 // 작성자 레코드 객체 (expand.editor)
+    author,
     createdAt,
+    updatedAt,
     currentUserId,
     infoClassName = "",
     showInfoHeader = true,
@@ -28,8 +20,8 @@ export default function InfoHeaderRowGroup({
     onDeletePost,
     onEditPost,
 
-    // StatusBadgeIconGroup 영역
-    iconName,               // 주어지면 그대로 사용, 없으면 postOwner 기반 계산
+    // StatusBadgeIconGroup
+    iconName,
     onIconClick,
     showSvgIcon,
     showEditAndDelete,
@@ -42,76 +34,60 @@ export default function InfoHeaderRowGroup({
     nameClass,
     timeClass,
 
-    // (선택) 파일 URL 계산 유틸: (record, fieldName) => string
     fileUrl,
+    onRequireLogin,
 
-    onRequireLogin,      // 로그아웃 시 호출할 가드
-
-    /** ✅ 추가: 좋아요 초깃값(숫자) */
     initialLikeCount = 0,
 }) {
     const [loadedItems, setLoadedItems] = useState([]);
 
-    // StatusBadgeIconGroup가 내부 fetch를 할 때를 대비한 post 보강
     const sourcePost = useMemo(
         () => post ?? loadedItems?.[0] ?? null,
         [post, loadedItems]
     );
 
-    // post에서 editor / created 파생(확장 없을 때 대비)
     const derived = useMemo(() => {
-        if (!sourcePost) return { dUser: null, dUserId: null, dCreatedAt: null };
+        if (!sourcePost) {
+            return { dUser: null, dUserId: null, dCreatedAt: null, dUpdatedAt: null };
+        }
 
         const pick = (ed) => {
-        if (!ed) return { dUser: null, dUserId: null };
-        if (typeof ed === "string") return { dUser: null, dUserId: ed };
-        if (typeof ed === "object" && ed.id) return { dUser: ed, dUserId: ed.id };
-        return { dUser: null, dUserId: null };
+            if (!ed) return { dUser: null, dUserId: null };
+            if (typeof ed === "string") return { dUser: null, dUserId: ed };
+            if (typeof ed === "object" && ed.id) return { dUser: ed, dUserId: ed.id };
+            return { dUser: null, dUserId: null };
         };
 
         let { dUser, dUserId } = pick(sourcePost.editor);
 
         const ex = sourcePost?.expand?.editor;
         if (ex) {
-        const u = Array.isArray(ex) ? ex[0] : ex;
-        if (u) {
-            dUser = u;
-            dUserId = u.id ?? dUserId;
-        }
+            const u = Array.isArray(ex) ? ex[0] : ex;
+            if (u) {
+                dUser = u;
+                dUserId = u.id ?? dUserId;
+            }
         }
 
-        const dCreatedAt = sourcePost?.updated || sourcePost?.created || null;
-        return { dUser, dUserId, dCreatedAt };
+        const dCreatedAt = sourcePost?.created || null;
+        const dUpdatedAt = sourcePost?.updated || null;
+        return { dUser, dUserId, dCreatedAt, dUpdatedAt };
     }, [sourcePost]);
 
-    // 최종 표시용 작성자/시간
     const finalAuthor = author ?? derived.dUser;
-    const finalCreatedAt = createdAt ?? derived.dCreatedAt;
 
-    // 아바타 URL 계산(있으면 fileUrl 사용)
+    // ✅ 명시 프롭 우선, 없으면 post에서 파생
+    const finalCreatedAt = createdAt ?? derived.dCreatedAt;
+    const finalUpdatedAt = updatedAt ?? derived.dUpdatedAt;
+
     const avatarUrl = useMemo(() => {
         if (!finalAuthor) return null;
-
-        // 1) 외부에서 fileUrl 제공 시: avatar 필드가 존재하면 사용
         if (typeof fileUrl === "function" && "avatar" in finalAuthor && finalAuthor.avatar) {
-        try {
-            return fileUrl(finalAuthor, "avatar");
-        } catch {
-            // noop
+            try { return fileUrl(finalAuthor, "avatar"); } catch { /* noop */ }
         }
-        }
-        // 2) 혹시 레코드에 avatarUrl 형태로 이미 들어있다면 사용
         return finalAuthor?.avatarUrl ?? finalAuthor?.avatar_url ?? null;
     }, [finalAuthor, fileUrl]);
 
-    // 작성자 이름
-    const displayName =
-        finalAuthor?.nickname ||
-        finalAuthor?.name ||
-        finalAuthor?.username ||
-        "알 수 없음";
-
-    // 아이콘 이름 결정: 명시 prop 우선 → 없으면 postOwner 기반
     const resolvedIconName = useMemo(() => {
         if (typeof iconName === "string") return iconName;
         return iconNameOf(sourcePost, currentUserId);
@@ -121,19 +97,20 @@ export default function InfoHeaderRowGroup({
         <div className={["w-full flex items-center justify-between gap-3", className].join(" ")}>
             {showInfoHeader && (
                 <InfoHeader
-                    user={finalAuthor}                 // 작성자 레코드 그대로 전달
+                    user={finalAuthor}
                     currentUserId={currentUserId}
                     createdAt={finalCreatedAt}
+                    updatedAt={finalUpdatedAt}
                     className={infoClassName}
                     nameClass={nameClass}
                     timeClass={timeClass}
-                    onRequireLogin={onRequireLogin}   // 로그아웃 시 호출할 가드
+                    onRequireLogin={onRequireLogin}
                 />
             )}
 
             <StatusBadgeIconGroup
                 post={post}
-                postId={post ? undefined : postId}        // post 없을 때만 내부 fetch
+                postId={post ? undefined : postId}
                 collection={collection}
                 onLoaded={(items) => setLoadedItems(items)}
                 onIconClick={onIconClick}

--- a/src/components/PostCard/PostCardCompact.jsx
+++ b/src/components/PostCard/PostCardCompact.jsx
@@ -106,7 +106,7 @@ export default function PostCardCompact({
                     }}
                 >
                     {/* 카테고리 + 타이틀 */}
-                    <div className="flex flex-col gap-1">
+                    <div className="flex flex-col gap-2">
                         <CategoryBadgeList
                             categories={post?.category ?? []}
                             className="flex-wrap"
@@ -165,6 +165,7 @@ export default function PostCardCompact({
                                     infoLikeSize={infoLikeSize}
                                 />
                                     <InfoComment
+                                        postId={post?.id}
                                         count={post?.commentCount ?? 0}
                                         infoCommentColor={infoCommentColor}
                                         infoCommentSize={infoCommentSize}

--- a/src/components/PostCard/PostCardCover.jsx
+++ b/src/components/PostCard/PostCardCover.jsx
@@ -81,7 +81,7 @@ export default function PostCardCover({
             <Link
                 to={`/post/detail/${post.id}`}
                 aria-label={`${post?.title ?? "모임"} 상세 보기`}
-                className="absolute inset-x-0 bottom-0 top-[56px] z-10"
+                className="absolute inset-x-0 bottom-0 top-[56px] z-20"
                 onClick={(e) => {
                     if (typeof onRequireLogin === "function") {
                         e.preventDefault();
@@ -165,12 +165,14 @@ export default function PostCardCover({
                             <InfoLike
                                 postId={post?.id}
                                 post={post}
-                                initialCount={likeSeed}                                count={true}
+                                initialCount={likeSeed}
+                                count={true}
                                 className="pointer-events-none"
                                 infoLikeColor={infoLikeColor}
                                 infoLikeSize={infoLikeSize}
                             />
                             <InfoComment
+                                postId={post?.id} 
                                 count={post?.commentCount ?? 0}
                                 infoCommentColor={infoCommentColor}
                                 infoCommentSize={infoCommentSize}

--- a/src/components/PostCard/PostCardSimple.jsx
+++ b/src/components/PostCard/PostCardSimple.jsx
@@ -21,7 +21,7 @@ export default function PostCardSimple({
     showSvgIcon,
     onDeletePost,
     onEditPost,
-    onRequireLogin,                // ✅ 비로그인 가드(선택)
+    onRequireLogin,
     initialLikeCount
 }) {
     const editorIdOf = (p) => {
@@ -100,7 +100,7 @@ export default function PostCardSimple({
 
                         {/* 우 정보 */}
                         <div className="w-0 flex-1 min-w-0 overflow-hidden flex flex-wrap gap-1">
-                            <div className="flex flex-col gap-1">
+                            <div className="flex flex-col gap-2">
                                 <CategoryBadgeList
                                     categories={post?.category ?? []}
                                     className="flex-wrap"

--- a/src/lib/deleteAccountWithConfirm.js
+++ b/src/lib/deleteAccountWithConfirm.js
@@ -36,10 +36,51 @@ export async function deleteAccountWithConfirm(userId, opts = {}) {
         collections = [
             { name: "post", ownerField: "editor" },
             { name: "post_draft", ownerField: "editor" },
+            // 주의: post_comments는 아래에서 ID 기반으로 따로 정리하므로 기본 배열에는 넣지 않음
         ],
     } = opts;
 
     const start = Date.now();
+
+    // 공통 유틸: 필터로 id 수집
+    async function collectIds(col, filter, pageSize = 50) {
+        const ids = [];
+        for (;;) {
+            const res = await pb.collection(col).getList(1, pageSize, { filter, fields: "id" });
+            const items = Array.isArray(res?.items) ? res.items : [];
+            if (items.length === 0) break;
+            for (const it of items) ids.push(it.id);
+            if (items.length < pageSize) break;
+        }
+        return ids;
+    }
+
+    // 공통 유틸: id 배열로 삭제(best-effort)
+    async function deleteByIds(col, ids) {
+        if (!ids?.length) return;
+        const results = await Promise.allSettled(ids.map((id) => pb.collection(col).delete(id)));
+        const failed = results.filter((r) => r.status === "rejected");
+        if (failed.length) {
+            console.warn(`[${col}] 일부 레코드 삭제 실패 (${failed.length}건)`);
+        }
+    }
+
+    // 공통 유틸: 필터로 페이지 순회 삭제(권한 허용 범위에서만 동작)
+    const deleteAllWhere = async (col, filter, pageSize = 50) => {
+        for (;;) {
+            const res = await pb.collection(col).getList(1, pageSize, { filter });
+            const items = Array.isArray(res?.items) ? res.items : [];
+            if (items.length === 0) break;
+
+            const results = await Promise.allSettled(
+                items.map((it) => pb.collection(col).delete(it.id))
+            );
+            const failed = results.filter((r) => r.status === "rejected");
+            if (failed.length > 0) {
+                throw new Error(`[${col}] 일부 레코드 삭제 실패 (${failed.length}건)`);
+            }
+        }
+    };
 
     // ✅ 탈퇴 유저 본인 것만 지우는 로컬 정리
     function clearLocalForUser(uid) {
@@ -90,26 +131,24 @@ export async function deleteAccountWithConfirm(userId, opts = {}) {
 
         before?.();
 
-        // 2) 관련 레코드 일괄 삭제
-        const deleteAllWhere = async (col, filter, pageSize = 50) => {
-            for (;;) {
-                const res = await pb.collection(col).getList(1, pageSize, { filter });
-                const items = Array.isArray(res?.items) ? res.items : [];
-                if (items.length === 0) break;
+        // 2) 🔎 선(先) 수집 — 포스트/유저 삭제 전에 댓글 id를 모두 확보
+        //    - a) 본인이 작성한 게시글 id
+        const ownedPostIds = await collectIds("post", `editor = "${userId}"`);
+        //    - b) 본인이 단 댓글
+        const commentIdsByUser = await collectIds("post_comments", `user = "${userId}"`);
+        //    - c) 본인 게시글에 달린 모든 댓글(다른 사람이 단 것 포함)
+        const commentIdsOnOwnedPosts = [];
+        for (const pid of ownedPostIds) {
+            const ids = await collectIds("post_comments", `post = "${pid}"`);
+            if (ids.length) commentIdsOnOwnedPosts.push(...ids);
+        }
+        const allCommentIds = Array.from(new Set([...commentIdsByUser, ...commentIdsOnOwnedPosts]));
 
-                const results = await Promise.allSettled(
-                    items.map((it) => pb.collection(col).delete(it.id))
-                );
-                const failed = results.filter((r) => r.status === "rejected");
-                if (failed.length > 0) {
-                    throw new Error(`[${col}] 일부 레코드 삭제 실패 (${failed.length}건)`);
-                }
-            }
-        };
-
+        // 3) 관련 레코드 일괄 삭제 (post_comments는 아래에서 id 기반으로 별도 처리)
         for (const c of collections) {
             const name = c?.name;
             if (!name) continue;
+            if (name === "post_comments") continue; // 안전장치
 
             const filter =
                 typeof c?.filter === "string" && c.filter.trim().length > 0
@@ -124,10 +163,19 @@ export async function deleteAccountWithConfirm(userId, opts = {}) {
             }
         }
 
-        // 3) 서버 계정 삭제
+        // 4) 🧹 수집한 id로 댓글 정리(베스트에포트)
+        //    - 권한 규칙에 따라 일부는 403이 날 수 있음(아래 'API Rule' 참고)
+        try {
+            await deleteByIds("post_comments", allCommentIds);
+        } catch (err) {
+            console.error("[deleteAccount] post_comments 정리 중 오류:", err);
+            // 계속 진행(최종 유저 삭제는 수행)
+        }
+
+        // 5) 서버 계정 삭제
         await pb.collection("users").delete(userId);
 
-        // 4) 인증 해제 & 로컬 정리(해당 유저의 likes_*만 제거)
+        // 6) 인증 해제 & 로컬 정리(해당 유저의 likes_*만 제거)
         try {
             pb.authStore?.clear?.();
         } catch (_) {}
@@ -138,7 +186,7 @@ export async function deleteAccountWithConfirm(userId, opts = {}) {
         }
         onSuccess?.();
 
-        // 5) 홈으로 이동
+        // 7) 홈으로 이동
         if (typeof navigate === "function") {
             navigate("/", { replace: true });
         } else {

--- a/src/lib/deletePostWithConfirm.js
+++ b/src/lib/deletePostWithConfirm.js
@@ -14,7 +14,7 @@ const SUBMIT_SKELETON_MIN_MS = Number(import.meta.env.VITE_SUBMIT_SKELETON_MIN_M
  * @param {Function} [opts.onError]  - 실패 시 호출
  * @param {Function} [opts.after]    - 로딩 스켈레톤 최소 시간 보장 후 호출
  * @param {object}   [opts.confirmOptions] - 모달 텍스트 커스터마이즈
- * @param {(msg:string, o?:{tone?:'success'|'error'}) => void} [opts.notify] - 성공/실패 알림(토스트 등)
+ * @param {(msg:string, o?:{tone?:'success'|'error'|'warning'}) => void} [opts.notify] - 성공/실패/경고 알림(토스트 등)
  */
 export async function deletePostWithConfirm(postId, opts = {}) {
     const {
@@ -28,6 +28,29 @@ export async function deletePostWithConfirm(postId, opts = {}) {
     } = opts;
 
     const start = Date.now();
+
+    // 내부 유틸: 필터로 id만 수집
+    async function collectIds(col, filter, pageSize = 50) {
+        const ids = [];
+        for (;;) {
+            const res = await pb.collection(col).getList(1, pageSize, { filter, fields: "id" });
+            const items = Array.isArray(res?.items) ? res.items : [];
+            if (items.length === 0) break;
+            for (const it of items) ids.push(it.id);
+            if (items.length < pageSize) break;
+        }
+        return ids;
+    }
+
+    // 내부 유틸: id 배열로 삭제(best-effort)
+    async function deleteByIds(col, ids) {
+        if (!ids?.length) return;
+        const results = await Promise.allSettled(ids.map((id) => pb.collection(col).delete(id)));
+        const failed = results.filter((r) => r.status === "rejected");
+        if (failed.length) {
+            console.warn(`[${col}] 일부 레코드 삭제 실패 (${failed.length}건)`);
+        }
+    }
 
     try {
         // ✅ 항상 네가 만든 Confirm 모달만 사용
@@ -46,12 +69,33 @@ export async function deletePostWithConfirm(postId, opts = {}) {
             tone: "danger",
             ...confirmOptions,
         });
-
         if (!ok) return;
 
         before?.();
 
-        await pb.collection("post").delete(postId);
+        // ★ 0) 댓글 id를 먼저 수집 (이후 post가 삭제되면 post=N/A가 되어 필터가 안먹음)
+        const commentIds = await collectIds("post_comments", `post = "${postId}"`);
+
+        // ★ 1) 게시글 먼저 삭제 (실패 시 전체 실패로 처리하고 댓글은 건드리지 않음)
+        try {
+            await pb.collection("post").delete(postId);
+        } catch (err) {
+            const code = err?.status || err?.response?.status || err?.data?.code;
+            const notFound = code === 404 || err?.response?.code === 404 || err?.data?.code === 404;
+            if (!notFound) {
+                throw err; // 권한(403) 등은 그대로 실패 처리
+            }
+        }
+
+        // ★ 2) 수집해둔 id로 댓글 정리(best-effort)
+        try {
+            await deleteByIds("post_comments", commentIds);
+        } catch (err) {
+            console.error("[deletePost] post_comments 정리 중 오류:", err);
+            if (typeof notify === "function") {
+                notify("댓글 정리 중 일부 오류가 있었지만 게시글은 삭제되었습니다.", { tone: "warning" });
+            }
+        }
 
         if (typeof notify === "function") {
             notify("삭제되었습니다.", { tone: "success" });

--- a/src/pages/PostDetail.jsx
+++ b/src/pages/PostDetail.jsx
@@ -35,6 +35,9 @@ import ProfileAvatar from "../components/User/ProfileAvatar";
 import CustomButton from "../components/CustomButton/CustomButton";
 import SvgIcon from "../components/SvgIcon/SvgIcon";
 import Input from "../components/Input/Input";
+import PostCommentForm from "../components/Comments/PostCommentForm";
+import PostCommentList from "../components/Comments/PostCommentList";
+
 import PostDetailSkeleton from "../components/Skeletons/PostDetailSkeleton";
 import { useConfirm } from "../components/Modal/ConfirmProvider";
 
@@ -503,55 +506,22 @@ export default function PostDetail() {
                                 <span className="h-[1px] w-full bg-[var(--color-gray-2)]" />
 
                                 {/* 댓글 */}
-                                <div>
-                                    <div className="flex flex-col gap-2">
-                                        <div className="flex flex-col gap-2">
-                                            <InfoComment variant="v2" count={post?.commentCount ?? 0} infoCommentColor={infoCommentColor} infoCommentSize={infoCommentSize} />
-                                            <Input
-                                                value={comment}
-                                                onChange={(e) => setComment(e.target.value)}
-                                                placeholder="최대 300자까지 가능해요."
-                                                name="요리모임에 대한 소개"
-                                                textarea
-                                            />
-                                        </div>
-                                        <CustomButton
-                                            text="댓글 작성"
-                                            size="sm"
-                                            custombuttonClass="self-end !w-[70px]"
-                                        />
-                                    </div>
+                                <div className="flex flex-col gap-2">
+                                    <InfoComment
+                                        variant="v2"
+                                        postId={post?.id} // ★ post_comments를 통해 합산
+                                        infoCommentColor={infoCommentColor}
+                                        infoCommentSize={infoCommentSize}
+                                    />
+                                    <PostCommentForm
+                                        postId={post?.id}
+                                        onCreated={() => { /* 목록/카운트는 실시간 구독으로 갱신됨. 필요 시 수동 트리거 가능 */ }}
+                                    />
                                 </div>
                                 {/* 댓글 받아오는 곳 */}
-                                <ul className="flex flex-col gap-3">
-                                    <li className="flex flex-col gap-2">
-                                        <InfoHeaderRowGroup
-                                            post={post}
-                                            user={authUser}                              
-                                            currentUserId={authUser?.id}                 
-                                            author={post?.expand?.editor ?? null}        
-                                            showSvgIcon={false}
-                                            showStatusBadge={false}
-                                            showEditAndDelete={isOwner ? true : false}
-                                        />
-                                        <p className={`whitespace-nowrap ${infoColor} ${infoSize}`}>사용자가 단 댓글</p>
-                                        <span className="h-[1px] w-full bg-[var(--color-gray-2)]" />
-                                    </li>
-                                    <li className="flex flex-col gap-2">
-                                        <InfoHeaderRowGroup
-                                            post={post}
-                                            user={authUser}                              
-                                            currentUserId={authUser?.id}                 
-                                            author={post?.expand?.editor ?? null}        
-                                            showSvgIcon={false}
-                                            showStatusBadge={false}
-                                            showEditAndDelete={isOwner ? true : false}
-                                        />
-                                        <p className={`whitespace-nowrap ${infoColor} ${infoSize}`}>사용자가 단 댓글</p>
-                                        <span className="h-[1px] w-full bg-[var(--color-gray-2)]" />
-                                    </li>
-                                </ul>
+                                <PostCommentList postId={post?.id} currentUser={authUser} />
                             </div>
+                            
                             {!isOwner ? (
                                 <div className="
                                     fixed 


### PR DESCRIPTION
## PR 이름
feat(comments): 댓글 시스템 1차 도입 — 등록/목록/수정/삭제 + 시간표기 일원화 + 카운트 실시간화 + 탈퇴·게시글 삭제 시 정리

- 수정한 이슈: 
#125 
#124 
#123 
#122 
#121

## 반영 브랜치
``` feature/post-comments ```

## PR 유형

- [x] 새로운 기능 추가
- [x] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 주석 추가 및 수정

## PR 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] 문서에 해당 변경 사항을 업데이트 했습니다.
- [x] 해당 변경은 에러를 발생시키지 않았습니다.

## PR 상세(활동 및 수정사항)
### 요약
- post_comments 컬렉션 기반 댓글 시스템 1차 도입
- PostDetail: 댓글 등록/목록/수정/삭제 연결, Confirm 모달 적용
- TimeBadge가 작성·수정 시각을 일괄 표시하도록 구조 정리(InfoHeader/RowGroup 연동)
- 댓글 카운트 실시간화: 카드·상세 모두 +1/-1 즉시 반영(PB 구독 + 로컬 이벤트)
- 계정/게시글 삭제 시 관련 댓글 레코드 정리(사전 ID 수집 → 안전 삭제)
- 자잘한 스타일링: 버튼 hover, 구분선 조건부 렌더링(아이템 ≥ 2), 텍스트 hover 등

### 수정파일
- src/components/Info/InfoComment.jsx : postId 지원 + PB subscribe 보강(delete 이벤트) + comments:changed 수신
- src/components/Badges/TimeBadge.jsx : created/updated 동시 지원, “· 수정됨 …” 표시
- src/components/Info/InfoHeader.jsx, src/components/Info/InfoHeaderRowGroup.jsx : TimeBadge에 createdAt/updatedAt 전달
- src/components/PostCard/PostCardCover.jsx, src/components/PostCard/PostCardCompact.jsx : InfoComment에 postId 전달(실시간 카운트)
- src/lib/deletePostWithConfirm.js : 게시글 삭제 전 댓글 ID 사전 수집 → 게시글 삭제 → 수집 ID로 댓글 정리
- src/lib/deleteAccountWithConfirm.js : 유저 탈퇴 전 소유 게시글 ID/본인 댓글 ID 사전 수집 → 관련 댓글 일괄 정리
- (스타일) 구분선 조건부 렌더링, 버튼/텍스트 hover 조정

### 테스트 시나리오
- [x] A 사용자로 로그인 → PostDetail 댓글 작성 → 즉시 “댓글 n개”가 +1
- [x] 댓글 수정 → TimeBadge “수정됨 …” 표시
- [x] 댓글 삭제 → 즉시 -1, 카드/상세 모두 반영
- [x]  deletePostWithConfirm로 게시글 삭제 → 관련 댓글이 PB에서 남지 않음
- [x]  deleteAccountWithConfirm로 유저 탈퇴 → 본인 댓글 + 본인 게시글의 모든 댓글이 정리