### PR TITLE
feat: 참여하기 전반 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.1.8",
+        "@tanstack/react-query": "^5.90.2",
         "pocketbase": "^0.26.0",
         "postcss": "^8.5.4",
         "react": "^19.1.0",
@@ -2331,6 +2332,32 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.11.tgz",
       "integrity": "sha512-2E9TBm6MDD/xKYe+dvJZAmg3yxIEDNRc0jwlNyDg/4Fil2QcSLjFKGVff0lAf1jjeaArlG/M75Ey/EYr/OJtBA==",
       "license": "MIT"
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.90.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.2.tgz",
+      "integrity": "sha512-k/TcR3YalnzibscALLwxeiLUub6jN5EDLwKDiO7q5f4ICEoptJ+n9+7vcEFy5/x/i6Q+Lb/tXrsKCggf5uQJXQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.90.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.2.tgz",
+      "integrity": "sha512-CLABiR+h5PYfOWr/z+vWFt5VsOA2ekQeRQBFSKlcoW6Ndx/f8rfyVmq4LbgOM4GG2qtxAxjLYLOpCNTYm4uKzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.90.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
     },
     "node_modules/@testing-library/dom": {
       "version": "10.4.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.8",
+    "@tanstack/react-query": "^5.90.2",
     "pocketbase": "^0.26.0",
     "postcss": "^8.5.4",
     "react": "^19.1.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,6 +15,7 @@ const PostDetail = lazy(() => import("./pages/PostDetail"));
 const PostEdit = lazy(() => import("./pages/PostEdit"));
 const MyInfoEdit = lazy(() => import("./pages/MyInfoEdit"));
 const PostLikes = lazy(() => import("./pages/PostLikes"));
+const PostParticipation = lazy(() => import("./pages/PostParticipation"));
 
 // 각 페이지 스켈레톤
 import PostCreateSkeleton from "./components/Skeletons/PostCreateSkeleton";
@@ -129,7 +130,7 @@ function App() {
                         <Route
                             path="/post/mypost/:userId"
                             element={
-                                <Suspense fallback={<PostCardSkeleton step={0} />}>
+                                <Suspense fallback={<PostCardSkeleton />}>
                                     <MyPosts />
                                 </Suspense>
                             }
@@ -137,7 +138,7 @@ function App() {
                         <Route
                             path="/post/likes/:userId"
                             element={
-                                <Suspense fallback={<PostCardSkeleton step={0} />}>
+                                <Suspense fallback={<PostCardSkeleton />}>
                                     <PostLikes />
                                 </Suspense>
                             }
@@ -151,6 +152,14 @@ function App() {
                             }
                         />
                         <Route path="/post/edit/:postId" element={<PostEdit />} />
+
+                        <Route 
+                            path="/post/participation/:userId" 
+                            element={
+                                <Suspense fallback={<PostCardSkeleton />}>
+                                    <PostParticipation />
+                                </Suspense>
+                            } />
                     </Route>
                 </Routes>
             </AuthProvider>

--- a/src/components/Badges/StatusBadgeList.jsx
+++ b/src/components/Badges/StatusBadgeList.jsx
@@ -7,7 +7,7 @@ import StatusBadge from "./StatusBadge";
 function getStatusesFromPost(post) {
     if (!post) return [];
 
-    // ✅ 정원/참여인원 기반 마감 판단
+    // ✅ 정원/예약인원 기반 마감 판단
     const cap = Number(post?.capacity ?? 0);
     const reserved = Number(
         post?.reservedCount ??
@@ -62,7 +62,7 @@ export default function StatusBadgeList({
 
         (async () => {
             try {
-                // ✅ 정원/참여 필드도 함께 가져오기
+                // ✅ 정원/예약 필드도 함께 가져오기
                 const rec = await pb
                     .collection(collection)
                     .getOne(postId, {

--- a/src/components/Badges/StatusBadgeList.jsx
+++ b/src/components/Badges/StatusBadgeList.jsx
@@ -1,3 +1,4 @@
+// src/components/Badges/StatusBadgeList.jsx
 import React, { useEffect, useRef, useState } from "react";
 import pb from "../../lib/pocketbase";
 import StatusBadge from "./StatusBadge";
@@ -5,6 +6,18 @@ import StatusBadge from "./StatusBadge";
 /** 상태 계산 */
 function getStatusesFromPost(post) {
     if (!post) return [];
+
+    // ✅ 정원/참여인원 기반 마감 판단
+    const cap = Number(post?.capacity ?? 0);
+    const reserved = Number(
+        post?.reservedCount ??
+        (Array.isArray(post?.reservations) ? post.reservations.length : post?.reservations ?? 0) ??
+        0
+    );
+    const isFull = cap > 0 && reserved >= cap;
+    if (isFull) return ["모집마감"];
+
+    // 기존 날짜/무료 로직
     const fee = post?.fee;
     const raw = post?.reservation ?? post?.date;
 
@@ -19,41 +32,29 @@ function getStatusesFromPost(post) {
     const diffDays =
         due == null ? Infinity : Math.ceil((due - today) / (1000 * 60 * 60 * 24));
 
-    const isClosed = due != null && diffDays <= 0;
+    const isClosedByDate = due != null && diffDays <= 0;
     const isImminent = due != null && diffDays > 0 && diffDays <= 3;
     const isFree = fee === 0 || fee === "0";
 
-    // 1) 모집마감
-    if (isClosed) return ["모집마감"];
-
-    // 2) 모집중 + 마감임박 + 무료클래스 → 마감임박, 무료클래스
+    if (isClosedByDate) return ["모집마감"];
     if (isImminent && isFree) return ["마감임박", "무료클래스"];
-
-    // 3) 모집중 + 마감임박 → 마감임박만
     if (isImminent) return ["마감임박"];
-
-    // 4) 모집중 + 무료클래스 → 모집중, 무료클래스
     if (isFree) return ["모집중", "무료클래스"];
-
-    // 5) 그 외 → 모집중만
     return ["모집중"];
 }
 
-export default function StatusBadgeList({ 
+export default function StatusBadgeList({
     posts = [],
-    postId, 
+    postId,
     collection = "post",
     onLoaded,
 }) {
     const [fetched, setFetched] = useState([]);
     const fetchedForIdRef = useRef(null);
 
-// postId로 내부 fetch (딱 한 번)
+    // postId로 내부 fetch (딱 한 번)
     useEffect(() => {
-        // posts가 이미 있으면 fetch 불필요
         if (posts.length) return;
-
-        // postId가 없거나 같은 id로 이미 가져왔으면 중복 방지
         if (!postId || fetchedForIdRef.current === postId) return;
 
         let mounted = true;
@@ -61,9 +62,12 @@ export default function StatusBadgeList({
 
         (async () => {
             try {
+                // ✅ 정원/참여 필드도 함께 가져오기
                 const rec = await pb
                     .collection(collection)
-                    .getOne(postId, { fields: "id,fee,reservation,date,editor,expand.editor" });
+                    .getOne(postId, {
+                        fields: "id,fee,reservation,date,capacity,reservations,editor,expand.editor",
+                    });
                 if (!mounted) return;
                 setFetched([rec]);
                 onLoaded?.([rec]);
@@ -87,13 +91,11 @@ export default function StatusBadgeList({
         <>
             {items.map((p, idx) => {
                 const statuses = p?._forceStatus ?? getStatusesFromPost(p);
-                if (!statuses?.length) return null; // ✅ 빈/undefined 방어
+                if (!statuses?.length) return null;
                 return (
                     <div key={p?.id ?? idx} className="flex flex-wrap gap-1">
                         {statuses.map((s, i) =>
-                            s ? ( // ✅ status가 falsy면 렌더 안 함 → "undefined" 표시 방지
-                                <StatusBadge key={`${p?.id ?? idx}-${s}-${i}`} status={s} />
-                            ) : null
+                            s ? <StatusBadge key={`${p?.id ?? idx}-${s}-${i}`} status={s} /> : null
                         )}
                     </div>
                 );

--- a/src/components/Info/InfoPeople.jsx
+++ b/src/components/Info/InfoPeople.jsx
@@ -1,12 +1,23 @@
+// src/components/Info/InfoPeople.jsx
 import React from "react";
 import SvgIcon from "../SvgIcon/SvgIcon";
+import ProfileAvatar from "../User/ProfileAvatar";
 
-export default function InfoPeople({ 
-    post, 
-    className = "", 
+/**
+ * 두 가지 모드 지원
+ * - 기본(인원수 모드): "0/10" 표기
+ * - 프로필 모드(showProfiles=true): 참여자 아바타 리스트
+ *   · profiles 가 비어있으면 "참여자가 없습니다." 문구 표기
+ */
+export default function InfoPeople({
+    post,
+    className = "",
     iconShow = true,
-    infoColor, 
+    infoColor,
     infoSize,
+    showProfiles = false,       // true면 프로필 모드
+    profiles = [],              // 프로필 모드에서 렌더할 사용자 배열
+    emptyText = "참여자가 없습니다.", // 프로필 모드에서 비어있을 때 문구
 }) {
     const reserved =
         post?.reservedCount ??
@@ -14,14 +25,44 @@ export default function InfoPeople({
         0;
     const cap = post?.capacity ?? 0;
 
+    if (showProfiles) {
+        const hasParticipants = Array.isArray(profiles) && profiles.length > 0;
+
+        return (
+            <div className={["w-full flex items-center", className].join(" ")}>
+                {hasParticipants ? (
+                    <div className="flex -space-x-2">
+                        {profiles.map((u, idx) => (
+                            <ProfileAvatar
+                                key={u?.id || idx}
+                                user={u}
+                                click={null}
+                            />
+                        ))}
+                    </div>
+                ) : (
+                    <span className={`${infoSize} ${infoColor}`}>{emptyText}</span>
+                )}
+            </div>
+        );
+    }
+
+    // 기본(인원수) 모드
     return (
         <div className={["w-full flex items-center", className].join(" ")}>
             {iconShow ? (
-                <SvgIcon name="user" frameSize="xs" frameClass="pointer-events-none" iconClass={`w-[16px] h-[16px] ${infoColor}`}/>)
-             : null }
-            
+                <SvgIcon
+                    name="user"
+                    frameSize="xs"
+                    frameClass="pointer-events-none"
+                    iconClass={`w-[16px] h-[16px] ${infoColor}`}
+                />
+            ) : null}
+
             <span className={`${infoSize} ${infoColor} truncate`}>
-                {reserved}<span className={`${infoColor} ${infoSize} px-[2px]`}>/</span>{cap}
+                {reserved}
+                <span className={`${infoColor} ${infoSize} px-[2px]`}>/</span>
+                {cap}
             </span>
         </div>
     );

--- a/src/components/Info/InfoPeople.jsx
+++ b/src/components/Info/InfoPeople.jsx
@@ -6,8 +6,8 @@ import ProfileAvatar from "../User/ProfileAvatar";
 /**
  * 두 가지 모드 지원
  * - 기본(인원수 모드): "0/10" 표기
- * - 프로필 모드(showProfiles=true): 참여자 아바타 리스트
- *   · profiles 가 비어있으면 "참여자가 없습니다." 문구 표기
+ * - 프로필 모드(showProfiles=true): 예약자 아바타 리스트
+ *   · profiles 가 비어있으면 "예약자가 없습니다." 문구 표기
  */
 export default function InfoPeople({
     post,
@@ -17,7 +17,7 @@ export default function InfoPeople({
     infoSize,
     showProfiles = false,       // true면 프로필 모드
     profiles = [],              // 프로필 모드에서 렌더할 사용자 배열
-    emptyText = "참여자가 없습니다.", // 프로필 모드에서 비어있을 때 문구
+    emptyText = "예약자가 없습니다.", // 프로필 모드에서 비어있을 때 문구
 }) {
     const reserved =
         post?.reservedCount ??

--- a/src/components/Info/InfoTitle.jsx
+++ b/src/components/Info/InfoTitle.jsx
@@ -24,7 +24,7 @@ export default function InfoTitle({
     return (
         <h3
             className={[
-                "line-clamp-2 break-keep",
+                "line-clamp-2",
                 sizeClass,
                 className,
                 titleoColor,

--- a/src/components/PostCard/PostCardCompact.jsx
+++ b/src/components/PostCard/PostCardCompact.jsx
@@ -12,6 +12,8 @@ import InfoComment from "../Info/InfoComment";
 import InfoTitle from "../Info/InfoTitle";
 import InfoDate from "../Info/InfoDate";
 import InfoTime from "../Info/InfoTime";
+import useParticipation from "../../hooks/useParticipation";
+import { useConfirm } from "../Modal/ConfirmProvider";
 
 export default function PostCardCompact({
     post,
@@ -46,6 +48,49 @@ export default function PostCardCompact({
             return u?.id ?? null;
         }
         return null;
+    };
+
+    const confirm = useConfirm();
+    const {
+        count, capacity, isClosed, isJoined,
+        join, cancel, joining, canceling,
+    } = useParticipation(post.id, user);
+
+    const notify = async (opt) => {
+        if (!confirm) return;
+        await confirm({
+            title: opt?.title || "알림",
+            description: opt?.description || "",
+            hideCancel: true,
+            confirmText: "확인",
+        });
+    };
+
+    const onClickParticipation = async () => {
+        try {
+            if (isJoined) {
+                const ok = confirm
+                    ? await confirm({ title: "참여 취소", description: "참여를 취소하시겠습니까?", confirmText: "확인", cancelText: "취소" })
+                    : true;
+                if (!ok) return;
+                await cancel();
+                await notify({ title: "취소 완료", description: "참여가 취소되었습니다." });
+            } else {
+                await join();
+                await notify({ title: "참여 완료", description: "참여가 완료되었습니다." });
+            }
+        } catch (err) {
+            const msg = String(err?.message || err);
+            if (msg.includes("NEED_LOGIN")) {
+                await notify({ title: "로그인이 필요합니다", description: "로그인 후 이용해주세요." });
+            } else if (msg.includes("FULL_CAPACITY")) {
+                await notify({ title: "모집마감", description: "모집이 마감되어 참여할 수 없습니다." });
+            } else if (msg.includes("unique") || msg.includes("Duplicate")) {
+                await notify({ title: "이미 참여 중", description: "이미 이 모임에 참여했습니다." });
+            } else {
+                await notify({ title: "오류", description: "요청 처리 중 문제가 발생했습니다." });
+            }
+        }
     };
 
     const isOwnerOf = (p, uid) => String(uid ?? "") === String(editorIdOf(p) ?? "");
@@ -114,7 +159,6 @@ export default function PostCardCompact({
                         <InfoTitle
                             title={post?.title}
                             titleoColor={titleoColor}
-                            className="!line-clamp-1 !break-normal"
                         />
                     </div>
 
@@ -130,7 +174,11 @@ export default function PostCardCompact({
                         {/* 우 정보 */}
                         <div className="flex-1 flex flex-col justify-between min-h-0">
                             <div className="w-full flex flex-wrap">
-                                <InfoPeople post={post} infoColor={infoColor} infoSize={infoSize} />
+                                <InfoPeople 
+                                    post={{ ...post, reservedCount: count, capacity }}
+                                    infoColor={infoColor} 
+                                    infoSize={infoSize}
+                                />
                                 <InfoLocation post={post} infoColor={infoColor} infoSize={infoSize} />
                                 <div className="w-full flex items-center">
                                     <InfoDate post={post} infoColor={infoColor} infoSize={infoSize} className="!w-auto" />
@@ -152,7 +200,6 @@ export default function PostCardCompact({
                                     /* ▼ 하단 아이콘은 항상 비어있는 하트로 고정 */
                                     readOnly={true}
                                     likedInitial={false}
-
                                     postId={post?.id}
                                     post={post}
                                     /** 리스트 하단 카운트도 같은 초깃값 숫자 사용 */
@@ -173,7 +220,15 @@ export default function PostCardCompact({
                                 </div>
 
                                 {!isOwnerOf(post, user?.id) ? (
-                                    <CustomButton text="예약하기" size="sm" custombuttonClass="!w-[78px]" />
+                                    <CustomButton 
+                                        text={isJoined ? "취소하기" : (isClosed ? "모집마감" : "참여하기")}
+                                        size="sm"
+                                        custombuttonClass="!w-[78px]" 
+                                        variant={isJoined ? "secondary" : "primary"}
+                                        state={!isJoined && isClosed ? "disable" : undefined}
+                                        disabled={(!isJoined && isClosed) || joining || canceling}
+                                        onClick={onClickParticipation}
+                                    />
                                 ) : null}
                             </div>
                         </div>

--- a/src/components/PostCard/PostCardCompact.jsx
+++ b/src/components/PostCard/PostCardCompact.jsx
@@ -28,7 +28,6 @@ export default function PostCardCompact({
     onDeletePost,
     onEditPost,
     onRequireLogin,
-    /** 부모가 내려주는 좋아요 초깃값(숫자). 없으면 post.likesCount 또는 0 */
     initialLikeCount,
 }) {
     const editorIdOf = (p) => {
@@ -70,23 +69,49 @@ export default function PostCardCompact({
         try {
             if (isJoined) {
                 const ok = confirm
-                    ? await confirm({ title: "참여 취소", description: "참여를 취소하시겠습니까?", confirmText: "확인", cancelText: "취소" })
+                    ? await confirm({
+                        title: "예약 취소",
+                        description: "예약을 취소하시겠습니까?",
+                        confirmText: "확인",
+                        cancelText: "취소",
+                    })
                     : true;
                 if (!ok) return;
+
                 await cancel();
-                await notify({ title: "취소 완료", description: "참여가 취소되었습니다." });
+
+                // 🔊 같은 탭의 목록(예약한 모임 등) 즉시 갱신
+                try {
+                    window.dispatchEvent(
+                        new CustomEvent("participation:changed", {
+                            detail: { postId: post.id, userId: user?.id, joined: false },
+                        })
+                    );
+                } catch {}
+
+                await notify({ title: "취소 완료", description: "예약이 취소되었습니다." });
             } else {
                 await join();
-                await notify({ title: "참여 완료", description: "참여가 완료되었습니다." });
+
+                // 🔊 예약 완료도 방송(필요 시 목록에 추가용)
+                try {
+                    window.dispatchEvent(
+                        new CustomEvent("participation:changed", {
+                            detail: { postId: post.id, userId: user?.id, joined: true },
+                        })
+                    );
+                } catch {}
+
+                await notify({ title: "예약 완료", description: "예약이 완료되었습니다." });
             }
         } catch (err) {
             const msg = String(err?.message || err);
             if (msg.includes("NEED_LOGIN")) {
                 await notify({ title: "로그인이 필요합니다", description: "로그인 후 이용해주세요." });
             } else if (msg.includes("FULL_CAPACITY")) {
-                await notify({ title: "모집마감", description: "모집이 마감되어 참여할 수 없습니다." });
+                await notify({ title: "모집마감", description: "모집이 마감되어 예약할 수 없습니다." });
             } else if (msg.includes("unique") || msg.includes("Duplicate")) {
-                await notify({ title: "이미 참여 중", description: "이미 이 모임에 참여했습니다." });
+                await notify({ title: "이미 예약 중", description: "이미 이 모임에 예약했습니다." });
             } else {
                 await notify({ title: "오류", description: "요청 처리 중 문제가 발생했습니다." });
             }
@@ -97,7 +122,6 @@ export default function PostCardCompact({
     const iconNameOf = (p, uid) => (isOwnerOf(p, uid) ? "kebabMenu" : "heart-1");
     const finalAuthor = author ?? post?.expand?.editor ?? null;
 
-    // 초깃값 숫자만 사용 (부모가 주면 그걸, 아니면 post.likesCount → 0)
     const likeSeed =
         typeof initialLikeCount === "number"
             ? initialLikeCount
@@ -114,7 +138,6 @@ export default function PostCardCompact({
 
     return (
         <div className={["relative rounded-2xl border border-[var(--color-gray-2)] bg-[var(--color-primary)] p-2", className].join(" ")}>
-            {/* 헤더(프로필/케밥/하트) - 클릭 제외 영역 */}
             <InfoHeaderRowGroup
                 post={{ ...post, reservedCount: count, capacity }}
                 user={user}
@@ -129,11 +152,9 @@ export default function PostCardCompact({
                 onDeletePost={onDeletePost}
                 onEditPost={onEditPost}
                 onRequireLogin={onRequireLogin}
-                /** 헤더 하트에도 같은 초깃값 숫자 전달 */
                 initialLikeCount={likeSeed}
             />
 
-            {/* 구분선 */}
             <div className="absolute left-0 right-0 h-[1px] w-full bg-[var(--color-gray-2)]" />
 
             <div className="flex flex-col gap-2 mt-4">
@@ -220,10 +241,10 @@ export default function PostCardCompact({
                                 </div>
 
                                 {!isOwnerOf(post, user?.id) ? (
-                                    <CustomButton 
-                                        text={isJoined ? "취소하기" : (isClosed ? "모집마감" : "참여하기")}
+                                    <CustomButton
+                                        text={isJoined ? "취소하기" : (isClosed ? "모집마감" : "예약하기")}
                                         size="sm"
-                                        custombuttonClass="!w-[78px]" 
+                                        custombuttonClass="!w-[78px]"
                                         variant={isJoined ? "secondary" : "primary"}
                                         state={!isJoined && isClosed ? "disable" : undefined}
                                         disabled={(!isJoined && isClosed) || joining || canceling}

--- a/src/components/PostCard/PostCardCompact.jsx
+++ b/src/components/PostCard/PostCardCompact.jsx
@@ -116,7 +116,7 @@ export default function PostCardCompact({
         <div className={["relative rounded-2xl border border-[var(--color-gray-2)] bg-[var(--color-primary)] p-2", className].join(" ")}>
             {/* 헤더(프로필/케밥/하트) - 클릭 제외 영역 */}
             <InfoHeaderRowGroup
-                post={post}
+                post={{ ...post, reservedCount: count, capacity }}
                 user={user}
                 currentUserId={user?.id}
                 author={finalAuthor}

--- a/src/components/PostCard/PostCardCover.jsx
+++ b/src/components/PostCard/PostCardCover.jsx
@@ -11,6 +11,7 @@ import InfoHeaderRowGroup from "../Info/InfoHeaderRowGroup";
 import InfoLocation from "../Info/InfoLocation";
 import InfoDate from "../Info/InfoDate";
 import InfoTime from "../Info/InfoTime";
+import useParticipation from "../../hooks/useParticipation";
 
 /**
  * 큰 커버 이미지 위에 정보 오버레이되는 카드
@@ -55,6 +56,7 @@ export default function PostCardCover({
 
         return null;
     };
+    
     const iconNameOf = (p, uid) =>
         String(uid ?? "") === String(editorIdOf(p) ?? "") ? "kebabMenu" : "heart-1";
 
@@ -66,6 +68,10 @@ export default function PostCardCover({
 
     // author가 없으면 post.expand.editor로 보강
     const finalAuthor = author ?? post?.expand?.editor ?? null;
+
+    const {
+        count, capacity,
+    } = useParticipation(post.id, user);
 
     const infoSize = "text-mo-text-sm tablet:text-tab-text desktop:text-pc-text-sm";
     const infoColor = "text-white text-mo-text-sm tablet:text-tab-text desktop:text-pc-text-sm";
@@ -101,9 +107,9 @@ export default function PostCardCover({
             />
 
             {/* 헤더(프로필/케밥/상태) — 오버레이 위(z-20) & 클릭 가능 */}
-            <div className="absolute top-0 flex justify-between w-full p-2 z-20 pointer-events-auto">
+            <div className="absolute top-0 flex justify-between w-full p-2 z-30 pointer-events-auto">
                 <InfoHeaderRowGroup
-                    post={post}
+                    post={{ ...post, reservedCount: count, capacity }}
                     user={user}
                     currentUserId={user?.id}         
                     author={finalAuthor}
@@ -142,7 +148,7 @@ export default function PostCardCover({
                 <div>
                     <div className="flex flex-wrap gap-x-1 text-[var(--color-gray-5)]">
                         <InfoPeople
-                            post={post}
+                            post={{ ...post, reservedCount: count, capacity }}
                             infoColor={infoColor}
                             infoSize={infoSize}
                             className="!w-auto"
@@ -163,10 +169,16 @@ export default function PostCardCover({
                         </div>
                         <div className="flex items-center gap-2">
                             <InfoLike
+                                /* ▼ 하단 아이콘은 항상 비어있는 하트로 고정 */
+                                readOnly={true}
+                                likedInitial={false}
                                 postId={post?.id}
                                 post={post}
+                                /** 리스트 하단 카운트도 같은 초깃값 숫자 사용 */
                                 initialCount={likeSeed}
                                 count={true}
+                                lazy={true}
+                                mode="passive"
                                 className="pointer-events-none"
                                 infoLikeColor={infoLikeColor}
                                 infoLikeSize={infoLikeSize}

--- a/src/components/PostCard/PostCardSimple.jsx
+++ b/src/components/PostCard/PostCardSimple.jsx
@@ -8,6 +8,7 @@ import InfoLocation from "../Info/InfoLocation";
 import InfoTitle from "../Info/InfoTitle";
 import InfoDate from "../Info/InfoDate";
 import InfoTime from "../Info/InfoTime";
+import useParticipation from "../../hooks/useParticipation";
 
 export default function PostCardSimple({
     post,
@@ -42,6 +43,11 @@ export default function PostCardSimple({
         }
         return null;
     };
+
+    const {
+        count, capacity, isClosed, isJoined,
+        join, cancel, joining, canceling,
+    } = useParticipation(post.id, user);
 
     // 초깃값 숫자만 사용 (부모가 주면 그걸, 아니면 post.likesCount → 0)
     const likeSeed =
@@ -112,7 +118,11 @@ export default function PostCardSimple({
                                 />
                             </div>
                             <div className="flex flex-wrap">
-                                <InfoPeople post={post} infoColor={infoColor} infoSize={infoSize} />
+                                <InfoPeople
+                                    post={{ ...post, reservedCount: count, capacity }} 
+                                    infoColor={infoColor} 
+                                    infoSize={infoSize}
+                                />
                                 <InfoLocation post={post} infoColor={infoColor} infoSize={infoSize} />
                                 <div className="w-full flex items-center">
                                     <InfoDate post={post} infoColor={infoColor} infoSize={infoSize} className="!w-auto" />

--- a/src/components/PostCard/PostCardSimple.jsx
+++ b/src/components/PostCard/PostCardSimple.jsx
@@ -65,7 +65,7 @@ export default function PostCardSimple({
     return (
         <div className={["relative rounded-2xl border border-[var(--color-gray-2)] bg-[var(--color-primary)] p-2", className].join(" ")}>
             <InfoHeaderRowGroup
-                post={post}
+                post={{ ...post, reservedCount: count, capacity }}
                 user={user}
                 currentUserId={user?.id}
                 author={author ?? post?.expand?.editor ?? null}

--- a/src/hooks/useParticipantsUsers.js
+++ b/src/hooks/useParticipantsUsers.js
@@ -1,0 +1,32 @@
+import { useQuery } from "@tanstack/react-query";
+import pb from "../lib/pocketbase";
+
+const COL = "post_participation";
+
+export default function useParticipantsUsers(postId) {
+    return useQuery({
+        queryKey: ["participants-users", postId],
+        enabled: !!postId, // postId 없으면 호출 안 함
+        queryFn: async () => {
+            try {
+                const res = await pb.collection(COL).getList(1, 200, {
+                    filter: `post = "${postId}"`,
+                    expand: "user",
+                    fields: "id,expand.user",
+                });
+                return (res?.items || [])
+                    .map((r) => r?.expand?.user)
+                    .filter(Boolean);
+            } catch (e) {
+                // RLS(401/403), 잘못된 컬렉션/훅 500 등은 일단 빈 배열 반환하여 화면이 죽지 않게
+                const code = e?.status || e?.data?.code;
+                if (code === 401 || code === 403 || code === 404 || code === 500) {
+                    return [];
+                }
+                throw e;
+            }
+        },
+        retry: false,
+        staleTime: 10000,
+    });
+}

--- a/src/hooks/useParticipation.js
+++ b/src/hooks/useParticipation.js
@@ -1,0 +1,75 @@
+import { useMemo } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import pb from "../lib/pocketbase";
+
+const COL = "post_participation";
+
+export default function useParticipation(postId, currentUser) {
+    const qc = useQueryClient();
+    const userId = currentUser?.id ?? null;
+
+    const { data, isLoading } = useQuery({
+        queryKey: ["participation", postId, userId],
+        enabled: !!postId,
+        queryFn: async () => {
+            const post = await pb.collection("post").getOne(postId);
+            const capacity = Number(post?.capacity || 0);
+
+            const list = await pb.collection(COL).getList(1, 1, {
+                filter: `post = "${postId}"`,
+            });
+            const count = Number(list?.totalItems ?? 0);
+
+            let mine = null;
+            if (userId) {
+                const mineList = await pb.collection(COL).getList(1, 1, {
+                    filter: `post = "${postId}" && user = "${userId}"`,
+                });
+                mine = mineList?.items?.[0] ?? null;
+            }
+
+            const closed = capacity > 0 && count >= capacity;
+            return { capacity, count, mine, closed };
+        },
+        staleTime: 10000,
+    });
+
+    const joinMutation = useMutation({
+        mutationFn: async () => {
+            if (!userId) {
+                const err = new Error("NEED_LOGIN");
+                throw err;
+            }
+            return pb.collection(COL).create({ post: postId, user: userId });
+        },
+        onSuccess: () => {
+            qc.invalidateQueries({ queryKey: ["participation", postId] });
+        },
+    });
+
+    const cancelMutation = useMutation({
+        mutationFn: async (joinId) => {
+            return pb.collection(COL).delete(joinId);
+        },
+        onSuccess: () => {
+            qc.invalidateQueries({ queryKey: ["participation", postId] });
+        },
+    });
+
+    const state = useMemo(() => ({
+        count: data?.count ?? 0,
+        capacity: data?.capacity ?? 0,
+        isJoined: !!data?.mine,
+        myJoinId: data?.mine?.id ?? null,
+        isClosed: !!data?.closed,
+        loading: isLoading,
+    }), [data, isLoading]);
+
+    return {
+        ...state,
+        join: () => joinMutation.mutateAsync(),
+        cancel: () => state.myJoinId && cancelMutation.mutateAsync(state.myJoinId),
+        joining: joinMutation.isPending,
+        canceling: cancelMutation.isPending,
+    };
+}

--- a/src/lib/NavItems.js
+++ b/src/lib/NavItems.js
@@ -18,6 +18,10 @@ export function useNavItems() {
         ? generatePath("/post/likes/:userId", { userId: user.id })
         : "/login";
 
+    const myParticipationTo = user
+        ? generatePath("/post/participation/:userId", { userId: user.id })
+        : "/login";
+
     const createTo = user ? "/post/create" : "/login";
 
     return React.useMemo(
@@ -551,7 +555,7 @@ export function useNavItems() {
                 },
             },
 
-            // 찜한 모임 (동적) — MyPosts와 동일한 노출 정책
+            // 찜한 모임 (동적)
             {
                 to: myLikesTo,
                 label: "찜한 모임",
@@ -569,6 +573,34 @@ export function useNavItems() {
             {
                 to: "/post/likes/:userId",
                 label: "찜한 모임",
+                showInNav: false,
+                header: {
+                    byScreen: {
+                        mobile: { showLogo: false, showHamburger: false, showBack: true, showNav: false, showTitle: true, Icon2Name: null, buttonTitle: null, showProfile: false },
+                        tablet: { showLogo: false, showHamburger: false, showBack: true, showNav: false, showTitle: true, Icon2Name: null, buttonTitle: null, showProfile: false },
+                        desktop: { showLogo: true, showHamburger: false, showBack: false, showNav: false, showTitle: false, Icon2Name: null, buttonTitle: null, showProfile: false },
+                    },
+                },
+            },
+
+            // 예약한 모임 (동적)
+            {
+                to: myParticipationTo,
+                label: "예약한 모임",
+                showInNav: true,
+                header: {
+                    byScreen: {
+                        mobile: { showLogo: false, showHamburger: false, showBack: true, showNav: false, showTitle: true, Icon2Name: null, buttonTitle: null, showProfile: false },
+                        tablet: { showLogo: false, showHamburger: false, showBack: true, showNav: false, showTitle: true, Icon2Name: null, buttonTitle: null, showProfile: false },
+                        desktop: { showLogo: true, showHamburger: false, showBack: false, showNav: false, showTitle: false, Icon2Name: null, buttonTitle: null, showProfile: false },
+                    },
+                },
+            },
+
+            // 다른 유저의 예약 목록 경로 매칭
+            {
+                to: "/post/participation/:userId",
+                label: "예약한 모임",
                 showInNav: false,
                 header: {
                     byScreen: {

--- a/src/lib/deleteAccountWithConfirm.js
+++ b/src/lib/deleteAccountWithConfirm.js
@@ -4,25 +4,8 @@ import pb from "./pocketbase";
 const SUBMIT_SKELETON_MIN_MS = Number(import.meta.env.VITE_SUBMIT_SKELETON_MIN_MS || 600);
 
 /**
- * 계정 삭제(탈퇴) 유틸 - 관련 레코드(게시글/임시저장 등) 먼저 삭제 후 계정 삭제
- *
- * @param {string} userId                            // 현재 탈퇴 대상 유저 id
- * @param {object} opts
- * @param {(o:{title?:string,description?:string,confirmText?:string,cancelText?:string,tone?:'default'|'danger'})=>Promise<boolean>} [opts.confirm]
- * @param {(msg:string, o?:{tone?:'success'|'error'})=>void} [opts.notify]
- * @param {Function} [opts.before]                   // 네트워크 전
- * @param {Function} [opts.after]                    // 스켈레톤 최소 노출 보장 후
- * @param {Function} [opts.onSuccess]                // 전부 성공 시
- * @param {(err:any)=>void} [opts.onError]           // 실패 시
- * @param {(path:string, o?:{replace?:boolean})=>void} [opts.navigate] // react-router navigate
- *
- * @param {Array<{name:string, ownerField?:string, filter?:string}>} [opts.collections]
- *   - 삭제할 관련 컬렉션 목록
- *   - ownerField: 기본은 "editor" (해당 필드가 userId인 레코드 삭제)
- *   - filter: 직접 필터 문자열을 주면 ownerField 대신 사용됨
- *
- * 기본 컬렉션:
- *   post(작성글), post_draft(임시저장) 를 대상으로 함
+ * 계정 삭제(탈퇴): 내가 쓴 글/임시글 + 내가 단 댓글/참여 + 내 글에 달린 댓글/참여 → 계정 삭제
+ * - 자식(댓글/참여) 먼저, 부모(게시글/계정) 나중
  */
 export async function deleteAccountWithConfirm(userId, opts = {}) {
     const {
@@ -33,177 +16,114 @@ export async function deleteAccountWithConfirm(userId, opts = {}) {
         onSuccess,
         onError,
         navigate,
-        collections = [
-            { name: "post", ownerField: "editor" },
-            { name: "post_draft", ownerField: "editor" },
-            // 주의: post_comments는 아래에서 ID 기반으로 따로 정리하므로 기본 배열에는 넣지 않음
-        ],
     } = opts;
 
     const start = Date.now();
+    const PARTICIPATION_TABLES = ["post_participation"];
 
-    // 공통 유틸: 필터로 id 수집
     async function collectIds(col, filter, pageSize = 50) {
-        const ids = [];
-        for (;;) {
-            const res = await pb.collection(col).getList(1, pageSize, { filter, fields: "id" });
-            const items = Array.isArray(res?.items) ? res.items : [];
-            if (items.length === 0) break;
-            for (const it of items) ids.push(it.id);
-            if (items.length < pageSize) break;
+        try {
+            const ids = [];
+            for (;;) {
+                const res = await pb.collection(col).getList(1, pageSize, { filter, fields: "id" });
+                const items = Array.isArray(res?.items) ? res.items : [];
+                if (!items.length) break;
+                for (const it of items) ids.push(it.id);
+                if (items.length < pageSize) break;
+            }
+            return ids;
+        } catch {
+            return [];
         }
-        return ids;
     }
-
-    // 공통 유틸: id 배열로 삭제(best-effort)
     async function deleteByIds(col, ids) {
         if (!ids?.length) return;
-        const results = await Promise.allSettled(ids.map((id) => pb.collection(col).delete(id)));
-        const failed = results.filter((r) => r.status === "rejected");
-        if (failed.length) {
-            console.warn(`[${col}] 일부 레코드 삭제 실패 (${failed.length}건)`);
+        await Promise.allSettled(ids.map((id) => pb.collection(col).delete(id)));
+    }
+    async function collectParticipationIds(filter) {
+        const set = new Set();
+        for (const col of PARTICIPATION_TABLES) {
+            const ids = await collectIds(col, filter);
+            ids.forEach((id) => set.add(id));
+        }
+        return [...set];
+    }
+    async function deleteParticipationByIds(ids) {
+        for (const col of PARTICIPATION_TABLES) {
+            await deleteByIds(col, ids);
         }
     }
 
-    // 공통 유틸: 필터로 페이지 순회 삭제(권한 허용 범위에서만 동작)
-    const deleteAllWhere = async (col, filter, pageSize = 50) => {
-        for (;;) {
-            const res = await pb.collection(col).getList(1, pageSize, { filter });
-            const items = Array.isArray(res?.items) ? res.items : [];
-            if (items.length === 0) break;
-
-            const results = await Promise.allSettled(
-                items.map((it) => pb.collection(col).delete(it.id))
-            );
-            const failed = results.filter((r) => r.status === "rejected");
-            if (failed.length > 0) {
-                throw new Error(`[${col}] 일부 레코드 삭제 실패 (${failed.length}건)`);
-            }
-        }
-    };
-
-    // ✅ 탈퇴 유저 본인 것만 지우는 로컬 정리
-    function clearLocalForUser(uid) {
+    // 로컬 좋아요 캐시 등 정리
+    function clearLocal(uid) {
         try {
-            // 1) 좋아요 캐시: 해당 유저 것만 제거
-            const likeKey = `likes_${uid}`;
-            localStorage.removeItem(likeKey);
-
-            // (혹시 예전 포맷을 쓴 적이 있다면 함께 정리)
-            localStorage.removeItem(`likes-${uid}`);
-            localStorage.removeItem(`likes:${uid}`);
-
-            // 2) 그 외 유저 소유 로컬 값(선택) — 본인일 때만 제거
-            if (localStorage.getItem("userId") === uid) {
-                localStorage.removeItem("userId");
-            }
-
-            // 3) 같은 탭 즉시 반영 + 다른 탭에도 동기화 알림
-            try {
-                window.dispatchEvent(
-                    new CustomEvent("likes:changed", {
-                        detail: { userId: uid, cleared: true },
-                    })
-                );
-                // storage 이벤트는 다른 탭에서만 자동 발생하므로 수동 트리거(최소 호환)
-                window.dispatchEvent(new Event("storage"));
-            } catch (_) {}
-        } catch (e) {
-            console.warn("clearLocalForUser failed:", e);
-        }
+            const keys = [`likes_${uid}`, `likes-${uid}`, `likes:${uid}`];
+            keys.forEach((k) => localStorage.removeItem(k));
+        } catch {}
     }
 
     try {
-        // 1) 확인 모달
-        let ok = true;
-        if (typeof confirm === "function") {
-            ok = await confirm({
-                title: "정말 탈퇴하시겠습니까?",
-                description: "작성하신 게시글, 임시저장 등 모든 데이터가 삭제되며 되돌릴 수 없습니다.",
-                confirmText: "탈퇴",
-                cancelText: "취소",
-                tone: "danger",
-            });
-        } else {
-            ok = window.confirm("정말 탈퇴하시겠습니까?");
-        }
+        const ok = await (typeof confirm === "function"
+            ? confirm({
+                  title: "정말 탈퇴하시겠습니까?",
+                  description: "작성한 게시글/임시저장/참여/댓글이 삭제되며 되돌릴 수 없습니다.",
+                  confirmText: "탈퇴",
+                  cancelText: "취소",
+                  tone: "danger",
+              })
+            : Promise.resolve(window.confirm("정말 탈퇴하시겠습니까?")));
         if (!ok) return;
 
         before?.();
 
-        // 2) 🔎 선(先) 수집 — 포스트/유저 삭제 전에 댓글 id를 모두 확보
-        //    - a) 본인이 작성한 게시글 id
-        const ownedPostIds = await collectIds("post", `editor = "${userId}"`);
-        //    - b) 본인이 단 댓글
-        const commentIdsByUser = await collectIds("post_comments", `user = "${userId}"`);
-        //    - c) 본인 게시글에 달린 모든 댓글(다른 사람이 단 것 포함)
-        const commentIdsOnOwnedPosts = [];
-        for (const pid of ownedPostIds) {
-            const ids = await collectIds("post_comments", `post = "${pid}"`);
-            if (ids.length) commentIdsOnOwnedPosts.push(...ids);
-        }
-        const allCommentIds = Array.from(new Set([...commentIdsByUser, ...commentIdsOnOwnedPosts]));
+        // 0) 내가 쓴 글 id
+        const myPostIds = await collectIds("post", `editor = "${userId}"`);
 
-        // 3) 관련 레코드 일괄 삭제 (post_comments는 아래에서 id 기반으로 별도 처리)
-        for (const c of collections) {
-            const name = c?.name;
-            if (!name) continue;
-            if (name === "post_comments") continue; // 안전장치
+        // 1) 자식 먼저 모두 수집
+        const myCommentIds = await collectIds("post_comments", `user = "${userId}"`);
+        const myJoinIds = await collectParticipationIds(`user = "${userId}"`);
 
-            const filter =
-                typeof c?.filter === "string" && c.filter.trim().length > 0
-                    ? c.filter
-                    : `${c?.ownerField ?? "editor"} = "${userId}"`;
+        const commentsOnMyPosts = [];
+        const joinsOnMyPosts = [];
+        for (const pid of myPostIds) {
+            const cids = await collectIds("post_comments", `post = "${pid}"`);
+            if (cids.length) commentsOnMyPosts.push(...cids);
 
-            try {
-                await deleteAllWhere(name, filter);
-            } catch (err) {
-                console.error(`[deleteAccount] ${name} 삭제 중 오류:`, err);
-                throw err;
-            }
+            const jids = await collectParticipationIds(`post = "${pid}"`);
+            if (jids.length) joinsOnMyPosts.push(...jids);
         }
 
-        // 4) 🧹 수집한 id로 댓글 정리(베스트에포트)
-        //    - 권한 규칙에 따라 일부는 403이 날 수 있음(아래 'API Rule' 참고)
-        try {
-            await deleteByIds("post_comments", allCommentIds);
-        } catch (err) {
-            console.error("[deleteAccount] post_comments 정리 중 오류:", err);
-            // 계속 진행(최종 유저 삭제는 수행)
-        }
+        // 2) 자식 삭제 (내가 쓴 것 + 내 글에 달린 것)
+        await deleteByIds("post_comments", [...new Set([...myCommentIds, ...commentsOnMyPosts])]);
+        await deleteParticipationByIds([...new Set([...myJoinIds, ...joinsOnMyPosts])]);
 
-        // 5) 서버 계정 삭제
+        // 3) 부모(내가 쓴 글/임시글 등) 삭제
+        await Promise.allSettled(
+            myPostIds.map((id) => pb.collection("post").delete(id))
+        );
+        await Promise.allSettled(
+            (await collectIds("post_draft", `editor = "${userId}"`))
+                .map((id) => pb.collection("post_draft").delete(id))
+        );
+
+        // 4) 계정 삭제
         await pb.collection("users").delete(userId);
 
-        // 6) 인증 해제 & 로컬 정리(해당 유저의 likes_*만 제거)
-        try {
-            pb.authStore?.clear?.();
-        } catch (_) {}
-        clearLocalForUser(userId);
+        // 5) 인증/로컬 정리
+        try { pb.authStore?.clear?.(); } catch {}
+        clearLocal(userId);
 
-        if (typeof notify === "function") {
-            notify("탈퇴가 완료되었습니다.", { tone: "success" });
-        }
+        notify?.("탈퇴가 완료되었습니다.", { tone: "success" });
         onSuccess?.();
 
-        // 7) 홈으로 이동
-        if (typeof navigate === "function") {
-            navigate("/", { replace: true });
-        } else {
-            window.location.replace("/");
-        }
+        if (typeof navigate === "function") navigate("/", { replace: true });
+        else window.location.replace("/");
     } catch (error) {
-        const details = error?.response?.data || error?.data;
-        console.error("탈퇴 실패:", error);
-        console.error("PocketBase details:", details);
-
-        if (typeof notify === "function") {
-            notify("탈퇴 처리 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.", { tone: "error" });
-        }
+        console.error("[deleteAccountWithConfirm] 실패:", error);
+        notify?.("탈퇴 처리 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.", { tone: "error" });
         onError?.(error);
     } finally {
-        const elapsed = Date.now() - start;
-        const remain = Math.max(0, SUBMIT_SKELETON_MIN_MS - elapsed);
+        const remain = Math.max(0, SUBMIT_SKELETON_MIN_MS - (Date.now() - start));
         setTimeout(() => after?.(), remain);
     }
 }

--- a/src/lib/deleteAccountWithConfirm.js
+++ b/src/lib/deleteAccountWithConfirm.js
@@ -4,8 +4,8 @@ import pb from "./pocketbase";
 const SUBMIT_SKELETON_MIN_MS = Number(import.meta.env.VITE_SUBMIT_SKELETON_MIN_MS || 600);
 
 /**
- * 계정 삭제(탈퇴): 내가 쓴 글/임시글 + 내가 단 댓글/참여 + 내 글에 달린 댓글/참여 → 계정 삭제
- * - 자식(댓글/참여) 먼저, 부모(게시글/계정) 나중
+ * 계정 삭제(탈퇴): 내가 쓴 글/임시글 + 내가 단 댓글/예약 + 내 글에 달린 댓글/예약 → 계정 삭제
+ * - 자식(댓글/예약) 먼저, 부모(게시글/계정) 나중
  */
 export async function deleteAccountWithConfirm(userId, opts = {}) {
     const {
@@ -66,7 +66,7 @@ export async function deleteAccountWithConfirm(userId, opts = {}) {
         const ok = await (typeof confirm === "function"
             ? confirm({
                   title: "정말 탈퇴하시겠습니까?",
-                  description: "작성한 게시글/임시저장/참여/댓글이 삭제되며 되돌릴 수 없습니다.",
+                  description: "작성한 게시글/임시저장/예약/댓글이 삭제되며 되돌릴 수 없습니다.",
                   confirmText: "탈퇴",
                   cancelText: "취소",
                   tone: "danger",

--- a/src/lib/deletePostWithConfirm.js
+++ b/src/lib/deletePostWithConfirm.js
@@ -59,7 +59,7 @@ export async function deletePostWithConfirm(postId, opts = {}) {
         }
         const ok = await confirm({
             title: "삭제하시겠습니까?",
-            description: "이 게시글과 관련 댓글/참여 기록을 삭제합니다. 되돌릴 수 없습니다.",
+            description: "이 게시글과 관련 댓글/예약 기록을 삭제합니다. 되돌릴 수 없습니다.",
             confirmText: "삭제",
             cancelText: "취소",
             tone: "danger",

--- a/src/lib/deletePostWithConfirm.js
+++ b/src/lib/deletePostWithConfirm.js
@@ -3,19 +3,6 @@ import pb from "./pocketbase";
 
 const SUBMIT_SKELETON_MIN_MS = Number(import.meta.env.VITE_SUBMIT_SKELETON_MIN_MS || 600);
 
-/**
- * 게시글 삭제 (항상 커스텀 Confirm 모달 사용)
- *
- * @param {string} postId
- * @param {object} opts
- * @param {(o: {title?:string, description?:string, confirmText?:string, cancelText?:string, tone?:'default'|'danger'}) => Promise<boolean>} opts.confirm - useConfirm 훅에서 받은 confirm 함수 (필수)
- * @param {Function} [opts.before]   - 삭제 요청 전 호출
- * @param {Function} [opts.onSuccess] - 성공 시 호출
- * @param {Function} [opts.onError]  - 실패 시 호출
- * @param {Function} [opts.after]    - 로딩 스켈레톤 최소 시간 보장 후 호출
- * @param {object}   [opts.confirmOptions] - 모달 텍스트 커스터마이즈
- * @param {(msg:string, o?:{tone?:'success'|'error'|'warning'}) => void} [opts.notify] - 성공/실패/경고 알림(토스트 등)
- */
 export async function deletePostWithConfirm(postId, opts = {}) {
     const {
         confirm,
@@ -28,42 +15,51 @@ export async function deletePostWithConfirm(postId, opts = {}) {
     } = opts;
 
     const start = Date.now();
+    const PARTICIPATION_TABLES = ["post_participation"];
 
-    // 내부 유틸: 필터로 id만 수집
     async function collectIds(col, filter, pageSize = 50) {
-        const ids = [];
-        for (;;) {
-            const res = await pb.collection(col).getList(1, pageSize, { filter, fields: "id" });
-            const items = Array.isArray(res?.items) ? res.items : [];
-            if (items.length === 0) break;
-            for (const it of items) ids.push(it.id);
-            if (items.length < pageSize) break;
+        try {
+            const ids = [];
+            for (;;) {
+                const res = await pb.collection(col).getList(1, pageSize, { filter, fields: "id" });
+                const items = Array.isArray(res?.items) ? res.items : [];
+                if (!items.length) break;
+                for (const it of items) ids.push(it.id);
+                if (items.length < pageSize) break;
+            }
+            return ids;
+        } catch {
+            return []; // 컬렉션 없음/권한 없음 → 무시
         }
-        return ids;
     }
 
-    // 내부 유틸: id 배열로 삭제(best-effort)
     async function deleteByIds(col, ids) {
         if (!ids?.length) return;
-        const results = await Promise.allSettled(ids.map((id) => pb.collection(col).delete(id)));
-        const failed = results.filter((r) => r.status === "rejected");
-        if (failed.length) {
-            console.warn(`[${col}] 일부 레코드 삭제 실패 (${failed.length}건)`);
+        await Promise.allSettled(ids.map((id) => pb.collection(col).delete(id)));
+    }
+
+    async function collectParticipationIds(filter) {
+        const set = new Set();
+        for (const col of PARTICIPATION_TABLES) {
+            const ids = await collectIds(col, filter);
+            ids.forEach((id) => set.add(id));
+        }
+        return [...set];
+    }
+    async function deleteParticipationByIds(ids) {
+        for (const col of PARTICIPATION_TABLES) {
+            await deleteByIds(col, ids);
         }
     }
 
     try {
-        // ✅ 항상 네가 만든 Confirm 모달만 사용
         if (typeof confirm !== "function") {
-            console.warn(
-                "deletePostWithConfirm: confirm 함수가 없습니다. useConfirm()으로 가져온 confirm을 opts.confirm에 전달하세요."
-            );
-            return; // confirm 없으면 아무 것도 하지 않음 (디자인 유지)
+            console.warn("deletePostWithConfirm: confirm 함수가 필요합니다.");
+            return;
         }
-
         const ok = await confirm({
             title: "삭제하시겠습니까?",
-            description: "이 게시글을 삭제합니다. 삭제 후 되돌릴 수 없습니다.",
+            description: "이 게시글과 관련 댓글/참여 기록을 삭제합니다. 되돌릴 수 없습니다.",
             confirmText: "삭제",
             cancelText: "취소",
             tone: "danger",
@@ -73,46 +69,25 @@ export async function deletePostWithConfirm(postId, opts = {}) {
 
         before?.();
 
-        // ★ 0) 댓글 id를 먼저 수집 (이후 post가 삭제되면 post=N/A가 되어 필터가 안먹음)
+        // 0) 자식 레코드 id 선 수집
         const commentIds = await collectIds("post_comments", `post = "${postId}"`);
+        const participationIds = await collectParticipationIds(`post = "${postId}"`);
 
-        // ★ 1) 게시글 먼저 삭제 (실패 시 전체 실패로 처리하고 댓글은 건드리지 않음)
-        try {
-            await pb.collection("post").delete(postId);
-        } catch (err) {
-            const code = err?.status || err?.response?.status || err?.data?.code;
-            const notFound = code === 404 || err?.response?.code === 404 || err?.data?.code === 404;
-            if (!notFound) {
-                throw err; // 권한(403) 등은 그대로 실패 처리
-            }
-        }
+        // 1) 자식부터 삭제 (권한 규칙상 게시글 작성자가 삭제 가능해야 함)
+        await deleteByIds("post_comments", commentIds);
+        await deleteParticipationByIds(participationIds);
 
-        // ★ 2) 수집해둔 id로 댓글 정리(best-effort)
-        try {
-            await deleteByIds("post_comments", commentIds);
-        } catch (err) {
-            console.error("[deletePost] post_comments 정리 중 오류:", err);
-            if (typeof notify === "function") {
-                notify("댓글 정리 중 일부 오류가 있었지만 게시글은 삭제되었습니다.", { tone: "warning" });
-            }
-        }
+        // 2) 부모(게시글) 삭제
+        await pb.collection("post").delete(postId);
 
-        if (typeof notify === "function") {
-            notify("삭제되었습니다.", { tone: "success" });
-        }
+        notify?.("삭제되었습니다.", { tone: "success" });
         onSuccess?.();
     } catch (error) {
-        const details = error?.response?.data || error?.data;
-        console.error("삭제 실패:", error);
-        console.error("PocketBase details:", details);
-
-        if (typeof notify === "function") {
-            notify("삭제에 실패했습니다. 잠시 후 다시 시도해주세요.", { tone: "error" });
-        }
+        console.error("[deletePostWithConfirm] 실패:", error);
+        notify?.("삭제에 실패했습니다. 잠시 후 다시 시도해주세요.", { tone: "error" });
         onError?.(error);
     } finally {
-        const elapsed = Date.now() - start;
-        const remain = Math.max(0, SUBMIT_SKELETON_MIN_MS - elapsed);
+        const remain = Math.max(0, SUBMIT_SKELETON_MIN_MS - (Date.now() - start));
         setTimeout(() => after?.(), remain);
     }
 }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,11 +3,16 @@ import { createRoot } from "react-dom/client";
 import "./styles/tailwind.css";
 import App from "./App.jsx";
 import ConfirmProvider from "./components/Modal/ConfirmProvider";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+const queryClient = new QueryClient();
 
 createRoot(document.getElementById('root')).render(
     <StrictMode>
-        <ConfirmProvider>
-            <App />
-        </ConfirmProvider>
-    </StrictMode>,
+        <QueryClientProvider client={queryClient}>
+            <ConfirmProvider>
+                <App />
+            </ConfirmProvider>
+        </QueryClientProvider>
+    </StrictMode>
 )

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -182,7 +182,7 @@ export default function MyPage() {
 
                                 <li className={textClasses.text}>
                                     <Link
-                                        to={generatePath("/post/likes/:userId", { userId: profileUser?.id ?? profileUser })}
+                                        to={generatePath("/post/likes/:userId", { userId: profileUser.id })}
                                         className="flex items-center justify-between"
                                     >
                                         <p>찜한 모임</p>
@@ -190,31 +190,15 @@ export default function MyPage() {
                                     </Link>
                                 </li>
 
-                                {isOwnPage && authUser && (
-                                    <>
-                                        <li className={textClasses.text}>
-                                            <Link className="flex items-center justify-between">
-                                                <p>예약한 모임</p>
-                                                <SvgIcon name="arrow-right" />
-                                            </Link>
-                                        </li>
-                                        <li className={textClasses.text}>
-                                            <Link
-                                                to={`/post/likes/${profileUser.id}`}
-                                                className="flex items-center justify-between"
-                                            >
-                                                <p>찜한 모임</p>
-                                                <SvgIcon name="arrow-right" />
-                                            </Link>
-                                        </li>
-                                        <li className={textClasses.text}>
-                                            <Link className="flex items-center justify-between">
-                                                <p>최근 본 모임</p>
-                                                <SvgIcon name="arrow-right" />
-                                            </Link>
-                                        </li>
-                                    </>
-                                )}
+                                <li className={textClasses.text}>
+                                    <Link
+                                        to={generatePath("/post/participation/:userId", { userId: profileUser.id })}
+                                        className="flex items-center justify-between"
+                                    >
+                                        <p>예약한 모임</p>
+                                        <SvgIcon name="arrow-right" />
+                                    </Link>
+                                </li>
                             </ul>
 
                             {/* 환경 설정: 다크모드 */}

--- a/src/pages/PostCreate.jsx
+++ b/src/pages/PostCreate.jsx
@@ -780,7 +780,7 @@ export default function PostCreate() {
                                         )}
                                     </li>
                                     <li className={LAYOUT_CLASSES.titleWrapper}>
-                                        <b className={TEXT_CLASSES.label}>참여인원</b>
+                                        <b className={TEXT_CLASSES.label}>예약인원</b>
                                         <div className={LAYOUT_CLASSES.InfoWrap}>
                                             <p className={TEXT_CLASSES.content}>{formData.capacity}</p>
                                             <b className={TEXT_CLASSES.content}>명</b>

--- a/src/pages/PostDetail.jsx
+++ b/src/pages/PostDetail.jsx
@@ -423,7 +423,7 @@ export default function PostDetail() {
                                 {/* Header */}
                                 <div className="flex flex-col gap-3 w-full mx-auto">
                                     <InfoHeaderRowGroup
-                                        post={post}
+                                        post={{ ...post, reservedCount: count, capacity }}
                                         user={authUser}
                                         currentUserId={authUser?.id}
                                         author={post?.expand?.editor ?? null}
@@ -437,7 +437,7 @@ export default function PostDetail() {
                                     <div className="flex items-center justify-between gap-4">
                                         <div className="flex flex-col gap-1">
                                             <StatusBadgeIconGroup
-                                                post={post}
+                                                post={{ ...post, reservedCount: count, capacity }}
                                                 className="hidden desktop:flex"
                                                 iconFrameClass="hidden"
                                                 showSvgIcon={false}
@@ -559,7 +559,7 @@ export default function PostDetail() {
                                 <div className="fixed w-full bottom-0 left-0 right-0 bg-[var(--color-primary)] border-t border-[var(--color-gray-2)] z-10 desktop:sticky desktop:top-20 desktop:h-full desktop:max-w-[348px] desktop:bg-transparent desktop:border-none">
                                     <div className="flex gap-2 w-full mx-auto flex-col px-[16px] py-2 desktop:px-0 desktop:py-0">
                                         <InfoHeaderRowGroup
-                                            post={post}
+                                            post={{ ...post, reservedCount: count, capacity }}
                                             user={authUser}
                                             currentUserId={authUser?.id}
                                             author={post?.expand?.editor ?? null}
@@ -592,7 +592,7 @@ export default function PostDetail() {
                                 <div className="hidden desktop:block fixed w-full bottom-0 left-0 right-0 bg-[var(--color-primary)] border-t border-[var(--color-gray-2)] z-10 desktop:sticky desktop:top-20 desktop:h-full desktop:max-w-[348px] desktop:bg-transparent desktop:border-none">
                                     <div className="flex gap-2 w-full mx-auto flex-col px-[16px] py-2 desktop:px-0 desktop:py-0">
                                         <InfoHeaderRowGroup
-                                            post={post}
+                                            post={{ ...post, reservedCount: count, capacity }}
                                             user={authUser}
                                             currentUserId={authUser?.id}
                                             author={post?.expand?.editor ?? null}

--- a/src/pages/PostDetail.jsx
+++ b/src/pages/PostDetail.jsx
@@ -1,5 +1,7 @@
+// src/pages/PostDetail.jsx
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
+import { useQueryClient } from "@tanstack/react-query";
 
 // 3rd-party (Swiper)
 import { Swiper, SwiperSlide } from "swiper/react";
@@ -9,6 +11,8 @@ import "swiper/css/navigation";
 
 // Hooks
 import useFetchFiles from "../hooks/useFetchFiles";
+import useParticipation from "../hooks/useParticipation";
+import useParticipantsUsers from "../hooks/useParticipantsUsers";
 
 // Context / Lib
 import { useAuth } from "../contexts/AuthContext";
@@ -31,17 +35,16 @@ import InfoFee from "../components/Info/InfoFee";
 import InfoLike from "../components/Info/InfoLike";
 import InfoDescription from "../components/Info/InfoDescription";
 import InfoComment from "../components/Info/InfoComment";
-import ProfileAvatar from "../components/User/ProfileAvatar";
 import CustomButton from "../components/CustomButton/CustomButton";
 import SvgIcon from "../components/SvgIcon/SvgIcon";
-import Input from "../components/Input/Input";
 import PostCommentForm from "../components/Comments/PostCommentForm";
 import PostCommentList from "../components/Comments/PostCommentList";
-
 import PostDetailSkeleton from "../components/Skeletons/PostDetailSkeleton";
 import { useConfirm } from "../components/Modal/ConfirmProvider";
 
 export default function PostDetail() {
+    const qc = useQueryClient();
+
     // Refs
     const prevRef = useRef(null);
     const nextRef = useRef(null);
@@ -52,10 +55,11 @@ export default function PostDetail() {
     const [post, setPost] = useState(null);
     const [err, setErr] = useState(null);
     const [likedOnDetail, setLikedOnDetail] = useState(false);
-    const [comment, setComment] = useState("");
     const { dataLoading } = useFetchFiles("files", 1, 50);
     const [isSubmitting, setIsSubmitting] = useState(false);
     const showSkeleton = dataLoading || isSubmitting;
+
+    // Modals
     const confirm = useConfirm();
 
     // Auth / Router
@@ -63,29 +67,105 @@ export default function PostDetail() {
     const { postId } = useParams();
     const navigate = useNavigate();
 
-    // Derived
+    // Owner check
     const isOwner = React.useMemo(
         () => isOwnerOf(post, authUser?.id),
         [post, authUser?.id]
     );
 
+    // Participation state
+    const {
+        count,
+        capacity,
+        isClosed,
+        isJoined,
+        join,
+        cancel,
+        joining,
+        canceling,
+        loading: partLoading,
+    } = useParticipation(post?.id, authUser);
+
+    // Participants (for avatar list)
+    const { data: participantsUsers = [] } = useParticipantsUsers(post?.id);
+
+    // Notify helper
+    const notify = async (opt) => {
+        if (!confirm) return;
+        await confirm({
+            title: opt?.title || "알림",
+            description: opt?.description || "",
+            hideCancel: true,
+            confirmText: "확인",
+        });
+    };
+
+    // Participate / Cancel
+    const onClickParticipation = async () => {
+        try {
+            if (!post?.id) return;
+
+            if (isJoined) {
+                const ok = await confirm({
+                    title: "참여 취소",
+                    description: "참여를 취소하시겠습니까?",
+                    confirmText: "확인",
+                    cancelText: "취소",
+                });
+                if (!ok) return;
+
+                await cancel();
+
+                // 낙관적 업데이트: 내 아바타 제거
+                qc.setQueryData(["participants-users", post.id], (old = []) =>
+                    old.filter((u) => u?.id !== authUser?.id)
+                );
+                // 재요청으로 최종 동기화
+                qc.invalidateQueries({ queryKey: ["participants-users", post.id] });
+                qc.invalidateQueries({ queryKey: ["participation", post.id] });
+
+                await notify({ title: "취소 완료", description: "참여가 취소되었습니다." });
+            } else {
+                await join();
+
+                // 낙관적 업데이트: 내 아바타 추가(중복 방지)
+                qc.setQueryData(["participants-users", post.id], (old = []) => {
+                    if (!authUser) return old;
+                    return old.some((u) => u?.id === authUser.id) ? old : [...old, authUser];
+                });
+                // 재요청으로 최종 동기화
+                qc.invalidateQueries({ queryKey: ["participants-users", post.id] });
+                qc.invalidateQueries({ queryKey: ["participation", post.id] });
+
+                await notify({ title: "참여 완료", description: "참여가 완료되었습니다." });
+            }
+        } catch (err) {
+            const msg = String(err?.message || err);
+            if (msg.includes("NEED_LOGIN")) {
+                await notify({ title: "로그인이 필요합니다", description: "로그인 후 이용해주세요." });
+            } else if (msg.includes("FULL_CAPACITY")) {
+                await notify({ title: "모집마감", description: "모집이 마감되어 참여할 수 없습니다." });
+            } else if (msg.includes("unique") || msg.includes("Duplicate")) {
+                await notify({ title: "이미 참여 중", description: "이미 이 모임에 참여했습니다." });
+            } else {
+                await notify({ title: "오류", description: "요청 처리 중 문제가 발생했습니다." });
+            }
+        }
+    };
+
     // Typography / color tokens
     const infoSize = "text-mo-text-md tablet:text-tab-text desktop:text-pc-text";
     const infoColor = "text-[var(--color-gray-7)]";
-
     const infoTitleSize = "text-mo-title-lg tablet:text-tab-title-md desktop:text-pc-title-md";
     const infoTitleColor = "text-[var(--color-gray-6)]";
-
     const titleSize = "font-bold text-mo-title-xl tablet:text-tab-title-xl desktop:text-pc-title-lg";
     const titleoColor = "text-[var(--color-gray-8)]";
-
     const infoCommentSize = "font-bold text-mo-text tablet:text-tab-text desktop:text-pc-text";
     const infoCommentColor = "text-[var(--color-gray-5)]";
-
     const infoLikeSize = "text-mo-text-sm tablet:text-tab-text desktop:text-pc-text-sm";
     const infoLikeColor = "text-[var(--color-gray-5)]";
 
-    // Fetch post
+    // Fetch post (with expand=editor as-is)
     useEffect(() => {
         let mounted = true;
         (async () => {
@@ -100,7 +180,7 @@ export default function PostDetail() {
         return () => { mounted = false; };
     }, [postId]);
 
-    // 네비게이션 바인딩/갱신
+    // Swiper navigation rebind
     useEffect(() => {
         if (!swiperInst) return;
 
@@ -127,7 +207,7 @@ export default function PostDetail() {
         return () => window.removeEventListener("resize", rebindNav);
     }, [swiperInst]);
 
-    // Images urls (memo)
+    // Image URLs
     const imgUrls = React.useMemo(() => {
         const files = Array.isArray(post?.images)
             ? post.images
@@ -142,7 +222,7 @@ export default function PostDetail() {
         setCurrentIndex(0);
     }, [imgUrls.length]);
 
-    // 게시물 삭제
+    // Delete post
     const handleDeleteHere = useCallback(() => {
         if (!post?.id) return;
         deletePostWithConfirm(post.id, {
@@ -155,47 +235,45 @@ export default function PostDetail() {
         });
     }, [post?.id, navigate, authUser?.id]);
 
-    // 게시물 수정
+    // Edit post
     const handleEditHere = useCallback(() => {
         if (!post?.id) return;
         location.assign(`/post/edit/${post.id}`);
     }, [post?.id]);
 
-    // 좋아요
+    // Likes (sync with storage/custom event)
     useEffect(() => {
         const userId = authUser?.id;
         if (!userId || !postId) return;
-      
+
         const key = `likes_${userId}`;
         const readLiked = () => {
-          try {
-            const raw = localStorage.getItem(key);
-            const arr = raw ? JSON.parse(raw) : [];
-            return arr.some((it) => it?.id === postId);
-          } catch {
-            return false;
-          }
+            try {
+                const raw = localStorage.getItem(key);
+                const arr = raw ? JSON.parse(raw) : [];
+                return arr.some((it) => it?.id === postId);
+            } catch {
+                return false;
+            }
         };
-      
-        // 초기 상태 동기화
+
         setLikedOnDetail(readLiked());
-      
-        // 실시간 동기화
+
         const onStorage = (e) => {
-          if (e.key === key) setLikedOnDetail(readLiked());
+            if (e.key === key) setLikedOnDetail(readLiked());
         };
         const onCustom = (e) => {
-          const d = e.detail;
-          if (d && d.userId === userId && d.postId === postId) setLikedOnDetail(d.liked);
+            const d = e.detail;
+            if (d && d.userId === userId && d.postId === postId) setLikedOnDetail(d.liked);
         };
-      
+
         window.addEventListener("storage", onStorage);
         window.addEventListener("likes:changed", onCustom);
         return () => {
-          window.removeEventListener("storage", onStorage);
-          window.removeEventListener("likes:changed", onCustom);
+            window.removeEventListener("storage", onStorage);
+            window.removeEventListener("likes:changed", onCustom);
         };
-      }, [authUser?.id, postId]);
+    }, [authUser?.id, postId]);
 
     return (
         <>
@@ -204,7 +282,7 @@ export default function PostDetail() {
             ) : (
                 <div className="mx-auto mt-[60px] mb-8 tablet:mt-8 desktop:mt-8">
                     <article className="flex flex-col tablet:px-[16px]">
-                        {/* 이미지 & 스와이퍼 */}
+                        {/* ===================== Images / Swiper ===================== */}
                         {(() => {
                             const files = Array.isArray(post?.images)
                                 ? post.images
@@ -215,8 +293,7 @@ export default function PostDetail() {
 
                             if (count <= 1) {
                                 return (
-                                    <div className="w-full mx-auto overflow-hidden 
-                                    tablet:relative tablet:max-w-[1060px] tablet:rounded-lg desktop:relative desktop:max-w-[1060px] desktop:rounded-lg">
+                                    <div className="w-full mx-auto overflow-hidden tablet:relative tablet:max-w-[1060px] tablet:rounded-lg desktop:relative desktop:max-w-[1060px] desktop:rounded-lg">
                                         {post?.images && (
                                             <div className="hidden absolute inset-0 -z-10 tablet:block desktop:block">
                                                 <div
@@ -226,20 +303,15 @@ export default function PostDetail() {
                                                 />
                                             </div>
                                         )}
-
                                         <InfoImage
                                             record={post}
                                             swiper={false}
-                                            className="relative z-10
-                                            w-full mx-auto
-                                            tablet:max-w-[500px] desktop:max-w-[500px]
-                                            aspect-[6/4]
-                                            rounded-none
-                                            overflow-hidden"
+                                            className="relative z-10 w-full mx-auto tablet:max-w-[500px] desktop:max-w-[500px] aspect-[6/4] rounded-none overflow-hidden"
                                         />
                                     </div>
                                 );
                             }
+
                             return (
                                 <div className="relative w-full mx-auto desktop:px-0 desktop:max-w-[1060px]">
                                     <Swiper
@@ -252,7 +324,7 @@ export default function PostDetail() {
                                         navigation={false}
                                         pagination={false}
                                         breakpoints={{
-                                            780:  { slidesPerView: 2, navigation: { enabled: true } },
+                                            780: { slidesPerView: 2, navigation: { enabled: true } },
                                             1060: { slidesPerView: 2, navigation: { enabled: true } },
                                         }}
                                         onBeforeInit={(swiper) => {
@@ -289,22 +361,12 @@ export default function PostDetail() {
                                                 </div>
                                             </SwiperSlide>
                                         ))}
+
                                         <button
                                             ref={prevRef}
                                             type="button"
                                             aria-label="이전 이미지"
-                                            className="
-                                                hidden tablet:flex
-                                                absolute left-2 top-1/2 -translate-y-1/2 z-20
-                                                h-10 w-10 rounded-full
-                                                items-center justify-center
-                                                bg-stone-400/[70%] hover:bg-stone-400/[50%] backdrop-blur-md
-                                                border border-[var(--color-gray-6)]
-                                                shadow-sm hover:shadow
-                                                transition
-                                                [&.swiper-button-disabled]:opacity-40
-                                                [&.swiper-button-disabled]:pointer-events-none
-                                            "
+                                            className="hidden tablet:flex absolute left-2 top-1/2 -translate-y-1/2 z-20 h-10 w-10 rounded-full items-center justify-center bg-stone-400/[70%] hover:bg-stone-400/[50%] backdrop-blur-md border border-[var(--color-gray-6)] shadow-sm hover:shadow transition [&.swiper-button-disabled]:opacity-40 [&.swiper-button-disabled]:pointer-events-none"
                                         >
                                             <SvgIcon
                                                 name="arrow-left"
@@ -317,18 +379,7 @@ export default function PostDetail() {
                                             ref={nextRef}
                                             type="button"
                                             aria-label="다음 이미지"
-                                            className="
-                                                hidden tablet:flex
-                                                absolute right-2 top-1/2 -translate-y-1/2 z-20
-                                                h-10 w-10 rounded-full
-                                                items-center justify-center
-                                                bg-stone-400/[70%] hover:bg-stone-400/[50%] backdrop-blur-md
-                                                border border-[var(--color-gray-6)]
-                                                shadow-sm hover:shadow
-                                                transition
-                                                [&.swiper-button-disabled]:opacity-40
-                                                [&.swiper-button-disabled]:pointer-events-none
-                                            "
+                                            className="hidden tablet:flex absolute right-2 top-1/2 -translate-y-1/2 z-20 h-10 w-10 rounded-full items-center justify-center bg-stone-400/[70%] hover:bg-stone-400/[50%] backdrop-blur-md border border-[var(--color-gray-6)] shadow-sm hover:shadow transition [&.swiper-button-disabled]:opacity-40 [&.swiper-button-disabled]:pointer-events-none"
                                         >
                                             <SvgIcon
                                                 name="arrow-right"
@@ -337,15 +388,9 @@ export default function PostDetail() {
                                             />
                                         </button>
                                     </Swiper>
+
                                     {imgUrls.length > 0 && (
-                                        <p
-                                            className="
-                                                tablet:hidden
-                                                desktop:hidden
-                                                absolute right-2 bottom-2
-                                                px-2 py-1 bg-stone-700/[70%] text-white text-sm rounded-md z-10
-                                            "
-                                        >
+                                        <p className="tablet:hidden desktop:hidden absolute right-2 bottom-2 px-2 py-1 bg-stone-700/[70%] text-white text-sm rounded-md z-10">
                                             {currentIndex + 1}/{imgUrls.length}
                                         </p>
                                     )}
@@ -353,64 +398,42 @@ export default function PostDetail() {
                             );
                         })()}
 
-                        {/* contentWrapper */}
-                        <div className="
-                            mt-4 mb-4 desktop:mt-6
-                            px-[16px] tablet:px-0 desktop:px-0
-                            w-full mx-auto
-                            desktop:max-w-[1060px] desktop:flex desktop:justify-between desktop:gap-4
-                        ">
-                            {/* desktop:heart */}
-                            <div className="
-                                hidden desktop:block
-                                z-10
-                                fixed
-                                bottom-0 left-0 right-0
-                                bg-[var(--color-primary)]
-                                border-t border-[var(--color-gray-2)]
-                                desktop:sticky desktop:top-20 desktop:h-full desktop:max-w-[348px] desktop:bg-transparent desktop:border-none
-                            ">
-                                <div className="
-                                    flex gap-2 w-full mx-auto
-                                    px-[16px] py-2
-                                    tablet:px-0
-                                    desktop:px-0 desktop:py-0
-                                    max-w-[500px]
-                                ">
+                        {/* ===================== Content Wrapper ===================== */}
+                        <div className="mt-4 mb-4 desktop:mt-6 px-[16px] tablet:px-0 desktop:px-0 w-full mx-auto desktop:max-w-[1060px] desktop:flex desktop:justify-between desktop:gap-4">
+                            {/* Left: desktop heart (sticky) */}
+                            <div className="hidden desktop:block z-10 fixed bottom-0 left-0 right-0 bg-[var(--color-primary)] border-t border-[var(--color-gray-2)] desktop:sticky desktop:top-20 desktop:h-full desktop:max-w-[348px] desktop:bg-transparent desktop:border-none">
+                                <div className="flex gap-2 w-full mx-auto px-[16px] py-2 tablet:px-0 desktop:px-0 desktop:py-0 max-w-[500px]">
                                     <InfoLike
                                         postId={post?.id}
                                         post={post}
                                         initialCount={0}
                                         count={true}
                                         lazy={false}
-                                        mode="active" // ★ 디테일만 서버에서 mine/total 조회
+                                        mode="active"
                                         aggregateAcrossUsers={true}
-                                        className="
-                                            hidden desktop:flex w-[50px] h-[50px] aspect-square
-                                            flex-col items-center justify-center bg-[var(--color-gray-2)] border border-[var(--color-gray-4)] rounded-full
-                                        " 
-                                        infoLikeSize={`${infoLikeSize}`} 
+                                        className="hidden desktop:flex w-[50px] h-[50px] aspect-square flex-col items-center justify-center bg-[var(--color-gray-2)] border border-[var(--color-gray-4)] rounded-full"
+                                        infoLikeSize={`${infoLikeSize}`}
                                         infoLikeColor={`${infoLikeColor}`}
                                     />
                                 </div>
                             </div>
+
+                            {/* Right: main content */}
                             <div className="flex flex-col gap-10 w-full">
-                                <div className="
-                                    flex flex-col gap-3
-                                    w-full mx-auto
-                                ">
+                                {/* Header */}
+                                <div className="flex flex-col gap-3 w-full mx-auto">
                                     <InfoHeaderRowGroup
                                         post={post}
-                                        user={authUser}                                  
-                                        currentUserId={authUser?.id}                     
-                                        author={post?.expand?.editor ?? null}            
+                                        user={authUser}
+                                        currentUserId={authUser?.id}
+                                        author={post?.expand?.editor ?? null}
                                         className="desktop:hidden"
                                         onDeletePost={handleDeleteHere}
                                         onEditPost={handleEditHere}
                                         showSvgIcon={isOwner ? true : false}
                                     />
-                                
-                                    {/* 타이틀 */}
+
+                                    {/* Title + mobile like */}
                                     <div className="flex items-center justify-between gap-4">
                                         <div className="flex flex-col gap-1">
                                             <StatusBadgeIconGroup
@@ -426,36 +449,34 @@ export default function PostDetail() {
                                                 titleoColor={titleoColor}
                                             />
                                         </div>
-                                        {/* mo/tab:heart */}
+
                                         <div className="desktop:hidden">
-                                            <InfoLike 
+                                            <InfoLike
                                                 postId={post?.id}
                                                 post={post}
                                                 initialCount={0}
                                                 count={true}
                                                 lazy={false}
                                                 aggregateAcrossUsers={true}
-                                                className="
-                                                    w-[60px] pl-[6px] pr-[12px]
-                                                    items-center justify-center bg-[var(--color-gray-2)] border border-[var(--color-gray-4)] rounded-full gap-1 hover:bg-[var(--color-gray-3)]
-                                                " 
-                                                infoLikeSize={`${infoLikeSize}`} 
+                                                className="w-[60px] pl-[6px] pr-[12px] items-center justify-center bg-[var(--color-gray-2)] border border-[var(--color-gray-4)] rounded-full gap-1 hover:bg-[var(--color-gray-3)]"
+                                                infoLikeSize={`${infoLikeSize}`}
                                                 infoLikeColor={`${infoLikeColor}`}
                                                 infoCountClass="tablet:translate-y-[1px]"
                                             />
                                         </div>
                                     </div>
+
+                                    {/* Info list */}
                                     <ul className="flex flex-col gap-4">
-                                        {/* 카테고리 */}
                                         <li className="flex flex-col gap-2">
                                             <b className={`${infoTitleSize} ${infoTitleColor}`}>모임할 테마</b>
                                             <CategoryBadgeList
                                                 categories={post?.category ?? []}
-                                                itemClassName={`font-normal`}
+                                                itemClassName="font-normal"
                                                 fontSize={infoSize}
                                             />
                                         </li>
-                                        {/* 날짜 + 시간 */}
+
                                         <li className="flex flex-col gap-2">
                                             <b className={`${infoTitleSize} ${infoTitleColor}`}>모임할 일정</b>
                                             <InfoDate post={post} infoColor={infoColor} infoSize={infoSize} className="!w-auto" />
@@ -464,7 +485,7 @@ export default function PostDetail() {
                                                     post={post}
                                                     infoColor={infoColor}
                                                     infoSize={infoSize}
-                                                    className="!w-auto gap-1 "
+                                                    className="!w-auto gap-1"
                                                     starClassName="px-[8px] py-[2px] text-[var(--color-gray-8)] ap bg-[var(--color-gray-2)] rounded-md whitespace-nowrap"
                                                     endClassName="px-[8px] py-[2px] text-[var(--color-gray-8)] ap bg-[var(--color-gray-2)] rounded-md whitespace-nowrap"
                                                     separator="부터"
@@ -472,83 +493,88 @@ export default function PostDetail() {
                                                 <span className={`${infoColor} ${infoSize}`}>까지</span>
                                             </div>
                                         </li>
-                                        {/* 위치 */}
+
                                         <li className="flex flex-col gap-2">
                                             <b className={`${infoTitleSize} ${infoTitleColor}`}>모임할 장소</b>
                                             <InfoLocation post={post} infoColor={infoColor} infoSize={infoSize} />
                                         </li>
-                                        {/* 참가비 */}
+
                                         <li className="flex flex-col gap-2">
                                             <b className={`${infoTitleSize} ${infoTitleColor}`}>참가비</b>
                                             <InfoFee post={post} infoColor={infoColor} infoSize={infoSize} />
                                         </li>
+
                                         <li className="flex flex-col gap-2">
                                             <b className={`${infoTitleSize} ${infoTitleColor}`}>모임할 장소</b>
-                                            <InfoDescription post={post} infoColor={infoColor} infoSize={infoSize} className="max-w-[620px]"/>
+                                            <InfoDescription post={post} infoColor={infoColor} infoSize={infoSize} className="max-w-[620px]" />
                                         </li>
-                                        {/* 예약자 */}
+
+                                        {/* 참여 인원 */}
                                         <li className="flex flex-col items-start gap-2">
-                                            <div className="flex gap-1">
+                                            <div className="flex gap-2">
                                                 <b className={`whitespace-nowrap ${infoTitleSize} ${infoTitleColor}`}>참여인원</b>
-                                                <InfoPeople post={post} infoColor={`text-[var(--color-gray-5)]`} infoSize={infoSize} iconShow={false} />
+                                                <InfoPeople
+                                                    post={{ ...post, reservedCount: count, capacity }}
+                                                    infoColor={`${infoTitleSize} ${infoTitleColor}`}
+                                                    infoSize={infoSize}
+                                                    iconShow={false}
+                                                />
                                             </div>
+
                                             <div className="flex -space-x-1">
-                                                <ProfileAvatar user={authUser} click={null} />
-                                                <ProfileAvatar user={authUser} click={null} />
-                                                <ProfileAvatar user={authUser} click={null} />
-                                                <ProfileAvatar user={authUser} click={null} />
+                                                <InfoPeople
+                                                    post={{ ...post, reservedCount: count, capacity }}
+                                                    showProfiles
+                                                    profiles={participantsUsers}
+                                                    infoColor="text-[var(--color-gray-5)]"
+                                                    infoSize={infoSize}
+                                                />
                                             </div>
                                         </li>
                                     </ul>
                                 </div>
 
-                                {/* 구분선 */}
+                                {/* Divider */}
                                 <span className="h-[1px] w-full bg-[var(--color-gray-2)]" />
 
-                                {/* 댓글 */}
+                                {/* Comments */}
                                 <div className="flex flex-col gap-2">
                                     <InfoComment
                                         variant="v2"
-                                        postId={post?.id} // ★ post_comments를 통해 합산
+                                        postId={post?.id}
                                         infoCommentColor={infoCommentColor}
                                         infoCommentSize={infoCommentSize}
                                     />
                                     <PostCommentForm
                                         postId={post?.id}
-                                        onCreated={() => { /* 목록/카운트는 실시간 구독으로 갱신됨. 필요 시 수동 트리거 가능 */ }}
+                                        onCreated={() => { /* 필요 시 갱신 트리거 */ }}
                                     />
                                 </div>
-                                {/* 댓글 받아오는 곳 */}
+
                                 <PostCommentList postId={post?.id} currentUser={authUser} />
                             </div>
-                            
+
+                            {/* Bottom action (not owner) */}
                             {!isOwner ? (
-                                <div className="
-                                    fixed 
-                                    w-full 
-                                    bottom-0 left-0 right-0 
-                                    bg-[var(--color-primary)] 
-                                    border-t border-[var(--color-gray-2)]
-                                    z-10
-                                    desktop:sticky desktop:top-20 desktop:h-full desktop:max-w-[348px] desktop:bg-transparent desktop:border-none
-                                ">
-                                    <div className="
-                                        flex gap-2 w-full mx-auto flex-col
-                                        px-[16px] py-2 desktop:px-0 desktop:py-0
-                                    ">
-                                        <InfoHeaderRowGroup 
-                                            post={post} 
-                                            user={authUser}                              
-                                            currentUserId={authUser?.id}                 
-                                            author={post?.expand?.editor ?? null}        
+                                <div className="fixed w-full bottom-0 left-0 right-0 bg-[var(--color-primary)] border-t border-[var(--color-gray-2)] z-10 desktop:sticky desktop:top-20 desktop:h-full desktop:max-w-[348px] desktop:bg-transparent desktop:border-none">
+                                    <div className="flex gap-2 w-full mx-auto flex-col px-[16px] py-2 desktop:px-0 desktop:py-0">
+                                        <InfoHeaderRowGroup
+                                            post={post}
+                                            user={authUser}
+                                            currentUserId={authUser?.id}
+                                            author={post?.expand?.editor ?? null}
                                             className="hidden desktop:flex"
                                             showStatusBadge={false}
                                             showSvgIcon={isOwner ? true : false}
                                         />
                                         <CustomButton
-                                            text="예약하기"
+                                            text={isJoined ? "취소하기" : (isClosed ? "모집마감" : "참여하기")}
                                             size="lg"
                                             custombuttonClass="w-full"
+                                            variant={isJoined ? "secondary" : "primary"}
+                                            state={!isJoined && isClosed ? "disable" : undefined}
+                                            disabled={(!isJoined && isClosed) || joining || canceling || partLoading}
+                                            onClick={onClickParticipation}
                                             infoLike
                                             infoLikeProps={{
                                                 postId: post?.id,
@@ -558,29 +584,18 @@ export default function PostDetail() {
                                                 infoLikeSize: "text-mo-text-sm tablet:text-tab-text desktop:text-pc-text-sm",
                                                 className: "desktop:hidden rounded-full hover:bg-[var(--color-gray-2)] transition w-[2.5rem] h-[2.5rem] shrink-0 flex items-center justify-center",
                                             }}
-                                            />
+                                        />
                                     </div>
                                 </div>
                             ) : (
-                                <div className="
-                                    hidden desktop:block
-                                    fixed 
-                                    w-full 
-                                    bottom-0 left-0 right-0 
-                                    bg-[var(--color-primary)] 
-                                    border-t border-[var(--color-gray-2)]
-                                    z-10
-                                    desktop:sticky desktop:top-20 desktop:h-full desktop:max-w-[348px] desktop:bg-transparent desktop:border-none
-                                ">
-                                    <div className="
-                                        flex gap-2 w-full mx-auto flex-col
-                                        px-[16px] py-2 desktop:px-0 desktop:py-0
-                                    ">
-                                        <InfoHeaderRowGroup 
-                                            post={post} 
-                                            user={authUser}                              
-                                            currentUserId={authUser?.id}                 
-                                            author={post?.expand?.editor ?? null}        
+                                // Bottom (owner)
+                                <div className="hidden desktop:block fixed w-full bottom-0 left-0 right-0 bg-[var(--color-primary)] border-t border-[var(--color-gray-2)] z-10 desktop:sticky desktop:top-20 desktop:h-full desktop:max-w-[348px] desktop:bg-transparent desktop:border-none">
+                                    <div className="flex gap-2 w-full mx-auto flex-col px-[16px] py-2 desktop:px-0 desktop:py-0">
+                                        <InfoHeaderRowGroup
+                                            post={post}
+                                            user={authUser}
+                                            currentUserId={authUser?.id}
+                                            author={post?.expand?.editor ?? null}
                                             className="hidden desktop:flex"
                                             showStatusBadge={false}
                                             showEditAndDelete={isOwner}

--- a/src/pages/PostDetail.jsx
+++ b/src/pages/PostDetail.jsx
@@ -107,8 +107,8 @@ export default function PostDetail() {
 
             if (isJoined) {
                 const ok = await confirm({
-                    title: "참여 취소",
-                    description: "참여를 취소하시겠습니까?",
+                    title: "예약 취소", 
+                    description: "예약을 취소하시겠습니까?",
                     confirmText: "확인",
                     cancelText: "취소",
                 });
@@ -124,7 +124,7 @@ export default function PostDetail() {
                 qc.invalidateQueries({ queryKey: ["participants-users", post.id] });
                 qc.invalidateQueries({ queryKey: ["participation", post.id] });
 
-                await notify({ title: "취소 완료", description: "참여가 취소되었습니다." });
+                await notify({ title: "취소 완료", description: "예약이 취소되었습니다." });
             } else {
                 await join();
 
@@ -137,16 +137,16 @@ export default function PostDetail() {
                 qc.invalidateQueries({ queryKey: ["participants-users", post.id] });
                 qc.invalidateQueries({ queryKey: ["participation", post.id] });
 
-                await notify({ title: "참여 완료", description: "참여가 완료되었습니다." });
+                await notify({ title: "예약 완료", description: "예약이 완료되었습니다." });
             }
         } catch (err) {
             const msg = String(err?.message || err);
             if (msg.includes("NEED_LOGIN")) {
                 await notify({ title: "로그인이 필요합니다", description: "로그인 후 이용해주세요." });
             } else if (msg.includes("FULL_CAPACITY")) {
-                await notify({ title: "모집마감", description: "모집이 마감되어 참여할 수 없습니다." });
+                await notify({ title: "모집마감", description: "모집이 마감되어 예약할 수 없습니다." });
             } else if (msg.includes("unique") || msg.includes("Duplicate")) {
-                await notify({ title: "이미 참여 중", description: "이미 이 모임에 참여했습니다." });
+                await notify({ title: "이미 예약 중", description: "이미 이 모임에 예약했습니다." });
             } else {
                 await notify({ title: "오류", description: "요청 처리 중 문제가 발생했습니다." });
             }
@@ -509,10 +509,10 @@ export default function PostDetail() {
                                             <InfoDescription post={post} infoColor={infoColor} infoSize={infoSize} className="max-w-[620px]" />
                                         </li>
 
-                                        {/* 참여 인원 */}
+                                        {/* 예약 인원 */}
                                         <li className="flex flex-col items-start gap-2">
                                             <div className="flex gap-2">
-                                                <b className={`whitespace-nowrap ${infoTitleSize} ${infoTitleColor}`}>참여인원</b>
+                                                <b className={`whitespace-nowrap ${infoTitleSize} ${infoTitleColor}`}>예약인원</b>
                                                 <InfoPeople
                                                     post={{ ...post, reservedCount: count, capacity }}
                                                     infoColor={`${infoTitleSize} ${infoTitleColor}`}
@@ -568,7 +568,7 @@ export default function PostDetail() {
                                             showSvgIcon={isOwner ? true : false}
                                         />
                                         <CustomButton
-                                            text={isJoined ? "취소하기" : (isClosed ? "모집마감" : "참여하기")}
+                                            text={isJoined ? "취소하기" : (isClosed ? "모집마감" : "예약하기")}
                                             size="lg"
                                             custombuttonClass="w-full"
                                             variant={isJoined ? "secondary" : "primary"}

--- a/src/pages/PostEdit.jsx
+++ b/src/pages/PostEdit.jsx
@@ -855,7 +855,7 @@ export default function PostEdit() {
                         )}
                         </li>
                         <li className={LAYOUT_CLASSES.titleWrapper}>
-                        <b className={TEXT_CLASSES.label}>참여인원</b>
+                        <b className={TEXT_CLASSES.label}>예약인원</b>
                         <div className={LAYOUT_CLASSES.InfoWrap}>
                             <p className={TEXT_CLASSES.content}>{formData.capacity}</p>
                             <b className={TEXT_CLASSES.content}>명</b>

--- a/src/pages/PostParticipation.jsx
+++ b/src/pages/PostParticipation.jsx
@@ -1,0 +1,172 @@
+// src/pages/PostParticipation.jsx
+import React, { useEffect, useRef, useState } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import PageTitleBar from "../components/PageTitleBar/PageTitleBar";
+import PostCardCompact from "../components/PostCard/PostCardCompact";
+import pb from "../lib/pocketbase";
+import { useAuth } from "../contexts/AuthContext";
+import { useConfirm } from "../components/Modal/ConfirmProvider";
+import { deletePostWithConfirm } from "../lib/deletePostWithConfirm";
+
+const PARTICIPATION = "post_participation";
+
+async function fetchParticipatedPostIdsByUser(userId) {
+    const ids = new Set();
+    let page = 1;
+    const perPage = 100;
+    for (;;) {
+        try {
+            const res = await pb.collection(PARTICIPATION).getList(page, perPage, {
+                filter: `user = "${String(userId)}"`,
+                fields: "post",
+            });
+            for (const it of res?.items || []) {
+                const pid = typeof it.post === "string" ? it.post : it?.post?.id;
+                if (pid) ids.add(pid);
+            }
+            if (!res?.items?.length || page >= (res?.totalPages || page)) break;
+            page += 1;
+        } catch {
+            break;
+        }
+    }
+    return [...ids];
+}
+
+async function hydratePosts(postIds) {
+    const out = [];
+    for (const id of postIds) {
+        try {
+            const rec = await pb.collection("post").getOne(id, { expand: "editor" });
+            out.push(rec);
+        } catch {}
+    }
+    return out;
+}
+
+export default function PostParticipation() {
+    const { userId } = useParams();
+    const { user: me } = useAuth();
+    const confirm = useConfirm();
+    const navigate = useNavigate();
+
+    const [posts, setPosts] = useState(null);
+    const loadingRef = useRef(false);
+
+    const load = async () => {
+        if (!userId || loadingRef.current) return;
+        loadingRef.current = true;
+        try {
+            setPosts(null);
+            const postIds = await fetchParticipatedPostIdsByUser(userId);
+            const hydrated = await hydratePosts(postIds);
+            setPosts(hydrated);
+        } finally {
+            loadingRef.current = false;
+        }
+    };
+
+    const handleDeleteInList = (postId) => {
+        if (!postId) return;
+        deletePostWithConfirm(postId, {
+            confirm,
+            onSuccess: () => {
+                setPosts((prev) => (prev || []).filter((p) => p.id !== postId));
+                window.dispatchEvent(new CustomEvent("post:deleted", { detail: { postId } }));
+            },
+        });
+    };
+    const handleEditInList = (postId) => {
+        if (!postId) return;
+        navigate(`/post/edit/${postId}`);
+    };
+
+    useEffect(() => {
+        load();
+
+        const onFocus = () => load();
+        const onVis = () => document.visibilityState === "visible" && load();
+        const onPostDeleted = (e) => {
+            const pid = e?.detail?.postId;
+            if (!pid) return;
+            setPosts((prev) => (prev || []).filter((p) => p.id !== pid));
+        };
+
+        // 예약/취소 즉시 반영(좋아요 페이지와 동일 패턴)
+        const onParticipationChanged = (e) => {
+            const { postId, userId: who, joined } = e?.detail || {};
+            if (!postId || String(who) !== String(userId)) return;
+            if (joined === false) {
+                setPosts((prev) => (prev || []).filter((p) => p.id !== postId));
+            }
+        };
+
+        window.addEventListener("focus", onFocus);
+        document.addEventListener("visibilitychange", onVis);
+        window.addEventListener("post:deleted", onPostDeleted);
+        window.addEventListener("participation:changed", onParticipationChanged);
+
+        // 서버에서 post 삭제되면 제거
+        let unsub;
+        (async () => {
+            try {
+                unsub = await pb.collection("post").subscribe("*", (e) => {
+                    if (e.action === "delete") {
+                        setPosts((prev) => (prev || []).filter((p) => p.id !== e.record?.id));
+                    }
+                });
+            } catch {}
+        })();
+
+        return () => {
+            window.removeEventListener("focus", onFocus);
+            document.removeEventListener("visibilitychange", onVis);
+            window.removeEventListener("post:deleted", onPostDeleted);
+            window.removeEventListener("participation:changed", onParticipationChanged);
+            try { pb.collection("post").unsubscribe("*"); } catch {}
+            if (typeof unsub === "function") try { unsub(); } catch {}
+        };
+    }, [userId, me?.id]);
+
+    return (
+        <>
+            <PageTitleBar title="예약한 모임" />
+
+            {posts === null ? (
+                <div className="h-screen flex items-center justify-center text-[var(--color-gray-5)]">
+                    불러오는 중…
+                </div>
+            ) : posts.length === 0 ? (
+                <div className="h-screen flex flex-col max-w=[500px] mx-auto items-center justify-center px-4 tablet:px-0 desktop:px-0">
+                    <p className="font-bold text-mo-title-md tablet:text-tab-title-md desktop:text-pc-title-md text-[var(--color-gray-5)] text-center">
+                        아직 예약한 모임이 없어요.
+                    </p>
+                </div>
+            ) : (
+                <ul className="flex flex-col gap-3 max-w-[500px] mx-auto mt-8 mb-8 px-[16px] tablet:px-0 desktop:px-0">
+                    {posts.map((post) => {
+                        const editorId =
+                            typeof post?.editor === "string"
+                                ? post.editor
+                                : post?.editor?.id || post?.expand?.editor?.id;
+                        const isOwner = editorId && me?.id && String(editorId) === String(me.id);
+
+                        return (
+                            <li key={post.id}>
+                                <PostCardCompact
+                                    post={post}
+                                    user={me}
+                                    showInfoHeader={true}
+                                    showStatusBadge={true}
+                                    showSvgIcon={true}
+                                    onDeletePost={isOwner ? () => handleDeleteInList(post.id) : undefined}
+                                    onEditPost={isOwner ? () => handleEditInList(post.id) : undefined}
+                                />
+                            </li>
+                        );
+                    })}
+                </ul>
+            )}
+        </>
+    );
+}


### PR DESCRIPTION
## PR 이름
feat: 참여하기 전반 구현

- 수정한 이슈: 

## 반영 브랜치
``` feature/post-participation ```

## PR 유형

- [x] 새로운 기능 추가
- [x] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [x] 빌드 부분 혹은 패키지 매니저 수정

## PR 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] 문서에 해당 변경 사항을 업데이트 했습니다.
- [x] 해당 변경은 에러를 발생시키지 않았습니다.

## PR 상세(활동 및 수정사항)

### 목표
- 예약 경험의 핵심 플로우를 완성하고, 리스트와 상세의 데이터 일관성을 보장합니다.
- 비로그인 사용자도 인원/마감 정보를 확인할 수 있어 탐색 경험이 향상됩니다.

### 변경 요약
- 삭제/탈퇴 시 예약 레코드 정리
   - deletePostWithConfirm: post_comments → post_participation → post 순으로 연쇄 삭제
   - deleteAccountWithConfirm: 내 예약 + 내 글의 예약 선삭제 후 글/계정 삭제
   - 실패 허용(Promise.allSettled) 및 모달 알림 유지
   - PB Delete Rule 정비(작성자/게시글 작성자 허용)
- 예약한 모임
   - /post/participation/:userId 페이지 추가(레이아웃 PostLikes 동일)
   - 예약/취소 시 participation:changed 브로드캐스트로 즉시 제거
   - PB realtime 구독으로 다른 탭/서버 이벤트 반영
- PocketBase
    - post_participation 컬렉션 생성, 유니크 인덱스(post+user), 권한 설정(List/View 공개)
- Hooks
    - useParticipation: count/capacity/isJoined/isClosed + join()/cancel() 낙관적 업데이트 및 ["participation", postId] 무효화
    - useParticipantsUsers: 예약자 expand=user 조회(상세 아바타) ["participants-users", postId] 무효화
- UI
   - InfoPeople: 숫자/프로필 2모드, 빈 상태 문구 “예약자가 없습니다.”
   - StatusBadgeList/IconGroup: 정원 마감 계산 추가(모집마감 뱃지)
   - PostDetail/PostCardCompact: 버튼 분기(예약/모집마감/취소), useConfirm() 모달 적용
   - 버튼 스타일: 예약 전(primary), 취소(secondary), 마감(primary+disabled)
- 즉시 갱신
   - join/cancel 시 아바타 목록 낙관적 반영 + 쿼리 무효화
- 에러 UX
   - 비로그인/정원 초과/중복 예약 각각 모달 문구 처리

### 스크린샷
- 예약자 없을 경우
<img width="300" height="366" alt="스크린샷 2025-09-28 오후 4 13 41" src="https://github.com/user-attachments/assets/1b7b0bfe-b65a-45d2-a58d-022d532e4e35" />

- 정원마감시

| 뱃지 “모집마감” | 버튼 비활성 |
|-------|-------|
| <img width="300" height="213" alt="스크린샷 2025-09-28 오후 4 09 21" src="https://github.com/user-attachments/assets/20fcf97c-8346-46d8-af5c-341df22f174a" />|<img width="300" height="758" alt="스크린샷 2025-09-28 오후 4 12 13" src="https://github.com/user-attachments/assets/1eba1a0f-df92-4c7a-bb22-a9b1b6f18b87" />|


### 체크리스트
- [x]  예약/취소 플로우 정상
- [x] 정원 마감 시 모든 뷰에 일관된 표시
- [x] 비로그인 인원·마감 가시성
- [x] 아바타 목록 및 빈 상태 문구
- [x] 회귀 없음(댓글/좋아요 등 기존 기능 영향 X)
- [x] 게시글 삭제 시 예약관련 레코드 삭제
- [x] 계정 탈퇴 시 예약관련 레코드 삭제